### PR TITLE
Afinity group hero template

### DIFF
--- a/src/heros/AffinityGroup/index.tsx
+++ b/src/heros/AffinityGroup/index.tsx
@@ -1,0 +1,61 @@
+'use client'
+import { useHeaderTheme } from '@/providers/HeaderTheme'
+import React, { useEffect } from 'react'
+
+import type { Page } from '@/payload-types'
+
+import { CMSLink } from '@/components/Link'
+import { Media } from '@/components/Media'
+import RichText from '@/components/RichText'
+
+export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richText }) => {
+  const { setHeaderTheme } = useHeaderTheme()
+
+  useEffect(() => {
+    setHeaderTheme('light')
+  })
+
+  return (
+    <section className="relative min-h-screen w-full overflow-hidden bg-background text-foreground font-sans">
+      {media && typeof media === 'object' && (
+        <Media fill imgClassName="object-cover opacity-60" priority resource={media} />
+      )}
+
+      <div className="absolute inset-0 bg-gradient-to-b from-white/40 via-white/10 to-white/60"></div>
+      <div className="relative z-10 container mx-auto px-6 md:px-12 pt-32 md:pt-48 flex flex-col items-center justify-center min-h-[80vh]">
+        <div className="glass rounded-3xl p-10 md:p-16 max-w-4xl text-center">
+          <span className="inline-block px-4 py-1.5 rounded-full bg-white/50 border border-white/60 backdrop-blur-sm text-primary font-semibold text-sm mb-6 shadow-sm">
+            Empowering Future Leaders
+          </span>
+          {richText && (
+            <RichText
+              className="text-5xl md:text-7xl lg:text-8xl font-heading font-bold leading-[1.1] tracking-tight mb-6 text-slate-900"
+              data={richText}
+              enableGutter={false}
+            />
+          )}
+          {Array.isArray(links) && links.length > 0 ? (
+            <div className="flex flex-wrap justify-center gap-4">
+              {links.map(({ link }, i) => (
+                <CMSLink
+                  key={i}
+                  {...link}
+                  className="px-8 py-4 rounded-full bg-slate-900 text-white font-medium hover:bg-slate-800 transition-all hover:shadow-xl"
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="flex flex-wrap justify-center gap-4">
+              <button className="px-8 py-4 rounded-full bg-slate-900 text-white font-medium hover:bg-slate-800 transition-all hover:shadow-xl">
+                Our Mission
+              </button>
+              <button className="px-8 py-4 rounded-full bg-white/60 backdrop-blur-md border border-white/50 text-slate-800 font-medium hover:bg-white transition-all hover:shadow-lg">
+                Learn More
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/heros/AffinityGroup/index.tsx
+++ b/src/heros/AffinityGroup/index.tsx
@@ -1,6 +1,5 @@
 'use client'
-import { useHeaderTheme } from '@/providers/HeaderTheme'
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import type { Page } from '@/payload-types'
 
@@ -9,12 +8,6 @@ import { Media } from '@/components/Media'
 import RichText from '@/components/RichText'
 
 export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richText, logo }) => {
-  const { setHeaderTheme } = useHeaderTheme()
-
-  useEffect(() => {
-    setHeaderTheme('light')
-  }, [setHeaderTheme])
-
   return (
     <section className="relative flex min-h-[68vh] items-center bg-slate-50 py-12 text-foreground dark:bg-slate-950 md:min-h-[60vh] md:py-16">
       <div className="container relative z-10 grid items-center gap-8 md:grid-cols-2 md:gap-12">

--- a/src/heros/AffinityGroup/index.tsx
+++ b/src/heros/AffinityGroup/index.tsx
@@ -8,53 +8,65 @@ import { CMSLink } from '@/components/Link'
 import { Media } from '@/components/Media'
 import RichText from '@/components/RichText'
 
-export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richText }) => {
+export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richText, logo }) => {
   const { setHeaderTheme } = useHeaderTheme()
 
   useEffect(() => {
     setHeaderTheme('light')
-  })
+  }, [setHeaderTheme])
 
   return (
-    <section className="relative min-h-screen w-full overflow-hidden bg-background text-foreground font-sans">
-      {media && typeof media === 'object' && (
-        <Media fill imgClassName="object-cover opacity-60" priority resource={media} />
-      )}
+    <section className="relative min-h-screen w-full bg-slate-50 dark:bg-slate-950 text-foreground font-sans flex items-center">
+      <div className="container mx-auto px-6 md:px-12 grid md:grid-cols-2 gap-12 items-center">
+        {/* LEFT SIDE */}
+        <div className="flex flex-col items-start gap-6">
+          {logo && typeof logo === 'object' && (
+            <Media resource={logo} imgClassName="w-20 h-20 object-contain" />
+          )}
 
-      <div className="absolute inset-0 bg-gradient-to-b from-white/40 via-white/10 to-white/60"></div>
-      <div className="relative z-10 container mx-auto px-6 md:px-12 pt-32 md:pt-48 flex flex-col items-center justify-center min-h-[80vh]">
-        <div className="glass rounded-3xl p-10 md:p-16 max-w-4xl text-center">
-          <span className="inline-block px-4 py-1.5 rounded-full bg-white/50 border border-white/60 backdrop-blur-sm text-primary font-semibold text-sm mb-6 shadow-sm">
-            Empowering Future Leaders
-          </span>
           {richText && (
             <RichText
-              className="text-5xl md:text-7xl lg:text-8xl font-heading font-bold leading-[1.1] tracking-tight mb-6 text-slate-900"
               data={richText}
               enableGutter={false}
+              className="
+                text-slate-900 dark:text-white
+                [&_h1]:text-5xl md:[&_h1]:text-6xl lg:[&_h1]:text-7xl
+                [&_h1]:font-heading [&_h1]:font-bold [&_h1]:leading-[1.05]
+                [&_h2]:text-3xl [&_h2]:font-semibold
+                [&_h3]:text-xl
+                [&_p]:text-lg [&_p]:mt-4
+                [&_p]:text-slate-600 dark:[&_p]:text-slate-400
+              "
             />
           )}
-          {Array.isArray(links) && links.length > 0 ? (
-            <div className="flex flex-wrap justify-center gap-4">
+
+          {Array.isArray(links) && links.length > 0 && (
+            <div className="flex flex-wrap gap-4 mt-4">
               {links.map(({ link }, i) => (
                 <CMSLink
                   key={i}
                   {...link}
-                  className="px-8 py-4 rounded-full bg-slate-900 text-white font-medium hover:bg-slate-800 transition-all hover:shadow-xl"
+                  className="
+                    px-8 py-4 rounded-full
+                    bg-slate-900 text-white
+                    dark:bg-white dark:text-slate-900
+                    font-medium
+                    hover:bg-slate-800
+                    dark:hover:bg-slate-200
+                    transition-all hover:shadow-xl
+                  "
                 />
               ))}
             </div>
-          ) : (
-            <div className="flex flex-wrap justify-center gap-4">
-              <button className="px-8 py-4 rounded-full bg-slate-900 text-white font-medium hover:bg-slate-800 transition-all hover:shadow-xl">
-                Our Mission
-              </button>
-              <button className="px-8 py-4 rounded-full bg-white/60 backdrop-blur-md border border-white/50 text-slate-800 font-medium hover:bg-white transition-all hover:shadow-lg">
-                Learn More
-              </button>
-            </div>
           )}
         </div>
+
+        {/* RIGHT SIDE IMAGE */}
+        {media && typeof media === 'object' && (
+          <div className="relative flex justify-center">
+            <Media resource={media} imgClassName="w-full max-w-3xl object-contain" />
+          </div>
+        )}
       </div>
     </section>
   )

--- a/src/heros/AffinityGroup/index.tsx
+++ b/src/heros/AffinityGroup/index.tsx
@@ -9,8 +9,8 @@ import RichText from '@/components/RichText'
 
 export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richText, logo }) => {
   return (
-    <section className="relative flex min-h-[68vh] items-center bg-slate-50 py-12 text-foreground dark:bg-slate-950 md:min-h-[60vh] md:py-16">
-      <div className="container relative z-10 grid items-center gap-8 md:grid-cols-2 md:gap-12">
+    <section className="relative -mt-16 bg-slate-50 py-8 text-foreground dark:bg-slate-950 md:py-10">
+      <div className="container relative z-10 grid items-start gap-8 md:grid-cols-2 md:gap-12">
         <div className="flex flex-col items-start gap-4 md:gap-6">
           {logo && typeof logo === 'object' && (
             <div className="mb-2">
@@ -44,8 +44,8 @@ export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richTe
             <Media
               priority
               resource={media}
-              className="w-full max-w-3xl overflow-hidden rounded-2xl border border-border bg-background"
-              imgClassName="w-full object-contain"
+              className="w-full max-w-2xl overflow-hidden rounded-2xl border border-border bg-background"
+              imgClassName="w-full max-h-[28rem] object-contain"
             />
           </div>
         )}

--- a/src/heros/AffinityGroup/index.tsx
+++ b/src/heros/AffinityGroup/index.tsx
@@ -16,52 +16,44 @@ export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richTe
   }, [setHeaderTheme])
 
   return (
-    <section className="relative min-h-screen w-full bg-slate-50 dark:bg-slate-950 text-foreground font-sans flex items-center">
-      <div className="container mx-auto px-6 md:px-12 grid md:grid-cols-2 gap-12 items-center">
-        {/* LEFT SIDE */}
-        <div className="flex flex-col items-start gap-6">
+    <section className="relative min-h-[80vh] md:min-h-[70vh] w-full bg-slate-50 dark:bg-slate-950 text-foreground font-sans flex items-center py-12 md:py-16">
+      <div className="container mx-auto px-6 md:px-12 grid md:grid-cols-2 gap-8 md:gap-12 items-center">
+        <div className="flex flex-col items-start gap-4 md:gap-6">
           {logo && typeof logo === 'object' && (
-            <Media resource={logo} imgClassName="w-20 h-20 object-contain" />
+            <div className="mb-2">
+              <Media resource={logo} imgClassName="w-16 h-16 md:w-20 md:h-20 object-contain" />
+            </div>
           )}
 
           {richText && (
             <RichText
               data={richText}
               enableGutter={false}
-              className="
-                text-slate-900 dark:text-white
-                [&_h1]:text-5xl md:[&_h1]:text-6xl lg:[&_h1]:text-7xl
-                [&_h1]:font-heading [&_h1]:font-bold [&_h1]:leading-[1.05]
-                [&_h2]:text-3xl [&_h2]:font-semibold
-                [&_h3]:text-xl
-                [&_p]:text-lg [&_p]:mt-4
-                [&_p]:text-slate-600 dark:[&_p]:text-slate-400
-              "
+              className="text-slate-900 dark:text-white"
             />
           )}
 
           {Array.isArray(links) && links.length > 0 && (
-            <div className="flex flex-wrap gap-4 mt-4">
+            <div className="flex flex-wrap gap-4 mt-2">
               {links.map(({ link }, i) => (
                 <CMSLink
                   key={i}
                   {...link}
-                  className="
-                    px-8 py-4 rounded-full
-                    bg-slate-900 text-white
-                    dark:bg-white dark:text-slate-900
-                    font-medium
-                    hover:bg-slate-800
-                    dark:hover:bg-slate-200
-                    transition-all hover:shadow-xl
-                  "
+                  className={`
+                    px-6 py-3 md:px-8 md:py-4 rounded-full font-medium
+                    transition-all hover:shadow-lg hover:scale-105
+                    ${
+                      i === 0
+                        ? 'bg-slate-900 text-white dark:bg-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-200'
+                        : 'bg-transparent border-2 border-slate-900 text-slate-900 dark:border-white dark:text-white hover:bg-slate-100 dark:hover:bg-slate-800'
+                    }
+                  `}
                 />
               ))}
             </div>
           )}
         </div>
 
-        {/* RIGHT SIDE IMAGE */}
         {media && typeof media === 'object' && (
           <div className="relative flex justify-center">
             <Media resource={media} imgClassName="w-full max-w-3xl object-contain" />

--- a/src/heros/AffinityGroup/index.tsx
+++ b/src/heros/AffinityGroup/index.tsx
@@ -16,8 +16,8 @@ export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richTe
   }, [setHeaderTheme])
 
   return (
-    <section className="relative min-h-[80vh] md:min-h-[70vh] w-full bg-slate-50 dark:bg-slate-950 text-foreground font-sans flex items-center py-12 md:py-16">
-      <div className="container mx-auto px-6 md:px-12 grid md:grid-cols-2 gap-8 md:gap-12 items-center">
+    <section className="relative flex min-h-[68vh] items-center bg-slate-50 py-12 text-foreground dark:bg-slate-950 md:min-h-[60vh] md:py-16">
+      <div className="container relative z-10 grid items-center gap-8 md:grid-cols-2 md:gap-12">
         <div className="flex flex-col items-start gap-4 md:gap-6">
           {logo && typeof logo === 'object' && (
             <div className="mb-2">
@@ -34,29 +34,26 @@ export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richTe
           )}
 
           {Array.isArray(links) && links.length > 0 && (
-            <div className="flex flex-wrap gap-4 mt-2">
-              {links.map(({ link }, i) => (
-                <CMSLink
-                  key={i}
-                  {...link}
-                  className={`
-                    px-6 py-3 md:px-8 md:py-4 rounded-full font-medium
-                    transition-all hover:shadow-lg hover:scale-105
-                    ${
-                      i === 0
-                        ? 'bg-slate-900 text-white dark:bg-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-200'
-                        : 'bg-transparent border-2 border-slate-900 text-slate-900 dark:border-white dark:text-white hover:bg-slate-100 dark:hover:bg-slate-800'
-                    }
-                  `}
-                />
-              ))}
-            </div>
+            <ul className="mt-2 flex flex-wrap gap-4">
+              {links.map(({ link }, i) => {
+                return (
+                  <li key={i}>
+                    <CMSLink {...link} />
+                  </li>
+                )
+              })}
+            </ul>
           )}
         </div>
 
         {media && typeof media === 'object' && (
-          <div className="relative flex justify-center">
-            <Media resource={media} imgClassName="w-full max-w-3xl object-contain" />
+          <div className="relative flex justify-center md:justify-end">
+            <Media
+              priority
+              resource={media}
+              className="w-full max-w-3xl overflow-hidden rounded-2xl border border-border bg-background"
+              imgClassName="w-full object-contain"
+            />
           </div>
         )}
       </div>

--- a/src/heros/RenderHero.tsx
+++ b/src/heros/RenderHero.tsx
@@ -5,11 +5,13 @@ import type { Page } from '@/payload-types'
 import { HighImpactHero } from '@/heros/HighImpact'
 import { LowImpactHero } from '@/heros/LowImpact'
 import { MediumImpactHero } from '@/heros/MediumImpact'
+import { AffinityGroupHero } from '@/heros/AffinityGroup'
 
 const heroes = {
   highImpact: HighImpactHero,
   lowImpact: LowImpactHero,
   mediumImpact: MediumImpactHero,
+  affinityGroup: AffinityGroupHero,
 }
 
 export const RenderHero: React.FC<Page['hero']> = (props) => {

--- a/src/heros/config.ts
+++ b/src/heros/config.ts
@@ -35,6 +35,10 @@ export const hero: Field = {
           label: 'Low Impact',
           value: 'lowImpact',
         },
+        {
+          label: 'Affinity Group',
+          value: 'affinityGroup',
+        },
       ],
       required: true,
     },
@@ -63,7 +67,8 @@ export const hero: Field = {
       name: 'media',
       type: 'upload',
       admin: {
-        condition: (_, { type } = {}) => ['highImpact', 'mediumImpact'].includes(type),
+        condition: (_, { type } = {}) =>
+          ['highImpact', 'mediumImpact', 'affinityGroup'].includes(type),
       },
       relationTo: 'media',
       required: true,

--- a/src/heros/config.ts
+++ b/src/heros/config.ts
@@ -68,6 +68,9 @@ export const hero: Field = {
       type: 'upload',
       relationTo: 'media',
       label: 'Logo (Affinity Group Only)',
+      admin: {
+        condition: (_, { type } = {}) => type === 'affinityGroup',
+      },
     },
     {
       name: 'media',

--- a/src/heros/config.ts
+++ b/src/heros/config.ts
@@ -60,9 +60,15 @@ export const hero: Field = {
     },
     linkGroup({
       overrides: {
-        maxRows: 2,
+        maxRows: 4,
       },
     }),
+    {
+      name: 'logo',
+      type: 'upload',
+      relationTo: 'media',
+      label: 'Logo (Affinity Group Only)',
+    },
     {
       name: 'media',
       type: 'upload',

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -214,6 +214,7 @@ export interface Page {
           id?: string | null;
         }[]
       | null;
+    logo?: (number | null) | Media;
     media?: (number | null) | Media;
   };
   layout: (CallToActionBlock | ContentBlock | MediaBlock | ArchiveBlock | FormBlock)[];
@@ -1327,6 +1328,7 @@ export interface PagesSelect<T extends boolean = true> {
                   };
               id?: T;
             };
+        logo?: T;
         media?: T;
       };
   layout?:

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -170,7 +170,7 @@ export interface Page {
   id: number;
   title: string;
   hero: {
-    type: 'none' | 'highImpact' | 'mediumImpact' | 'lowImpact';
+    type: 'none' | 'highImpact' | 'mediumImpact' | 'lowImpact' | 'affinityGroup';
     richText?: {
       root: {
         type: string;


### PR DESCRIPTION
Hero template to be used for afinity groups (sub chapters). Has media, 2-column layout and logo, as well as other configs. 

Screenshots:

<img width="2785" height="4292" alt="image" src="https://github.com/user-attachments/assets/1e266af8-68ed-4f39-9c02-cc5dc461b7ce" />
<img width="2785" height="4292" alt="image" src="https://github.com/user-attachments/assets/2a75a745-bc60-42ed-bf7b-469d0a008b3d" />

Also edited a config file to only have the logo option show up when the hero is set to affinityGroup

when not affinityGroup:
<img width="1810" height="1391" alt="image" src="https://github.com/user-attachments/assets/a7e9bbf0-a7d8-446c-962d-230decf282a3" />
when affinityGroup:
<img width="1810" height="1391" alt="image" src="https://github.com/user-attachments/assets/860fd310-cd07-44ce-ba70-9bea5607e83b" />
