### PR TITLE
Database backups

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       POSTGRES_URL: ${{ secrets.POSTGRES_URL_NO_POOLING }}
       BACKUP_POSTGRES_URL: ${{ secrets.BACKUP_POSTGRES_URL_NO_POOLING }}
+      BACKUP_ENCRYPTION_PUBLIC_KEY: ${{ secrets.BACKUP_ENCRYPTION_PUBLIC_KEY }}
       PG_BIN: /usr/lib/postgresql/17/bin
 
     steps:
@@ -19,14 +20,15 @@ jobs:
         run: |
           test -n "$POSTGRES_URL"
           test -n "$BACKUP_POSTGRES_URL"
+          test -n "$BACKUP_ENCRYPTION_PUBLIC_KEY"
 
-      - name: Install PostgreSQL 17 client
+      - name: Install PostgreSQL 17 client and age
         run: |
           sudo install -d /usr/share/postgresql-common/pgdg
           sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
           echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
           sudo apt-get update
-          sudo apt-get install -y postgresql-client-17
+          sudo apt-get install -y postgresql-client-17 age
 
       - name: Create SQL backup
         run: |
@@ -57,9 +59,27 @@ jobs:
         run: |
           "$PG_BIN/psql" "$BACKUP_POSTGRES_URL" -v ON_ERROR_STOP=1 -f "$BACKUP_FILE"
 
-      - name: Upload SQL backup artifact
+      - name: Compress and encrypt SQL backup
+        run: |
+          RECIPIENT_FILE="$(mktemp)"
+          trap 'rm -f "$RECIPIENT_FILE"' EXIT
+
+          printf '%s\n' "$BACKUP_ENCRYPTION_PUBLIC_KEY" > "$RECIPIENT_FILE"
+
+          gzip -9 "$BACKUP_FILE"
+          COMPRESSED_BACKUP_FILE="$BACKUP_FILE.gz"
+
+          age --encrypt \
+            --recipients-file "$RECIPIENT_FILE" \
+            --output "$COMPRESSED_BACKUP_FILE.age" \
+            "$COMPRESSED_BACKUP_FILE"
+
+          rm -f "$COMPRESSED_BACKUP_FILE"
+
+      - name: Upload encrypted SQL backup artifact
         uses: actions/upload-artifact@v4
         with:
-          name: postgres-backup
-          path: backups/*.sql
+          name: postgres-backup-encrypted
+          path: backups/*.sql.gz.age
+          if-no-files-found: error
           retention-days: 7

--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ This command will check for any migrations that have not yet been run and try to
 
 > _WARNING: Migrations are a pain in the ass to work with. Please be careful as they can easily corrupt the production database if done incorrectly. Only run migrations if you know what you're doing. ⚠️_
 
+### Backups
+
+In order to avoid having to redo everything from scratch in the event of data loss, we create database backups every 3 days, apply them to a backup database (useful for a quick fix), and store snapshots as encrypted artifacts containing SQL files that can reconstruct the state of the database at the time of the snapshot. This is all done through a single GitHub Actions script, [`database-backup.yml`](./.github/workflows/database-backup.yml).
+
+Only the webmaster can recover snapshots. GitHub Actions only has access to the public key, which is enough to encrypt new backups but not enough to read old ones.
+
+For more context about backups, you can read this PR: [Database backups](https://github.com/ieee-webmaster/ieeeuottawa-v3/pull/48)
+
 ### Internationalization / Localization
 
 We use [`next-intl`](https://next-intl.dev/) to implement localization (`l10n`) and internationalization (`i18n`). All website content must be available in both English and French. Any content added to the CMS must be translated into both languages (unless intentionally non-localized, such as brand names) and entered in the appropriate language view using the language switcher in the top-right corner of the admin panel. For static content (for example, section titles and subtitles), use the dedicated language files: [French](/messages/fr.json) and [English](/messages/en.json).


### PR DESCRIPTION
The database-backup.yml is used by GitHub to create a Database Backup workflow that runs essentially every 3 days at 3:00 AM UTC. It takes 2 Github Actions secrets (POSTGRES_URL_NO_POOLING and BACKUP_POSTGRES_URL_NO_POOLING), installs PostgresSQL 17 (neon uses this, wouldn't work with the default which is 16), uses pg_dump to produce the backup sql file, then applies it to the backup database and makes available an artifact that we can download (and that is kept by GitHub for a couple days). The workflow can be ran manually on the GitHub Actions workflow page of the repository. It only runs on the default branch (main).

To decrypt the artifact, you will need to download [`age`](https://github.com/filosottile/age), and then run the following:
```bash
age -d -i ~/.ssh/ieee-webmaster -o backup.sql.gz backup-YYYY-MM-DDTHH-MM-SSZ.sql.gz.age
```
ignoring the flags, in order, the arguments are the private ssh key, the output file, and the input file (the artifact's path)

Then you'll have a gzip archive that you can simply extract with `gunzip` or whatever tool you're using.

The workflow is currently disabled for security reasons, but I will enable it as soon as this is merged.

<img width="2404" height="1406" alt="image" src="https://github.com/user-attachments/assets/5eba161e-87f7-44d3-b688-f54995dd5757" />
