### PR TITLE
feat: Windows 2000 / IE6 visual redesign

### DIFF
--- a/src/Footer/Component.tsx
+++ b/src/Footer/Component.tsx
@@ -15,26 +15,89 @@ export async function Footer() {
   const navItems = footerData?.navItems || []
 
   return (
-    <footer className="mt-auto border-t border-primary bg-primary text-primary-foreground">
-      <div className="container py-8 flex flex-col gap-6">
-        <div className="flex flex-col md:flex-row md:justify-between md:items-start gap-4 w-full">
-          <Link className="flex items-center" href="/">
-            <Logo />
-          </Link>
+    <footer
+      className="mt-auto w-full"
+      style={{ fontFamily: "'Tahoma','MS Sans Serif','Arial',sans-serif", fontSize: '11px' }}
+    >
+      {/* Win2k panel footer body */}
+      <div
+        className="px-4 py-4"
+        style={{
+          backgroundColor: 'var(--win-silver)',
+          borderTop: '2px solid var(--win-dark)',
+        }}
+      >
+        <div className="container flex flex-col md:flex-row md:justify-between md:items-start gap-4">
+          {/* Logo block with sunken panel */}
+          <div
+            className="win-sunken p-2 inline-block"
+            style={{ backgroundColor: '#fff' }}
+          >
+            <Link href="/">
+              <Logo className="invert-0 dark:invert" />
+            </Link>
+          </div>
 
-          <nav className="flex flex-wrap gap-4 md:justify-end">
+          {/* Nav links */}
+          <nav className="flex flex-wrap gap-x-4 gap-y-1">
             {navItems.map(({ link }, i) => (
-              <CMSLink key={i} {...link} />
+              <CMSLink
+                key={i}
+                {...link}
+                className="text-xs underline text-foreground hover:text-primary"
+              />
             ))}
           </nav>
-        </div>
-
-        <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-4">
-          <p className="text-xs opacity-70 text-center md:text-left">
-            &copy; {currentYear} IEEE UOttawa. All rights reserved.
-          </p>
 
           <ThemeSelector />
+        </div>
+      </div>
+
+      {/* Win2k status bar */}
+      <div
+        className="flex items-center justify-between px-4 py-0.5 gap-4"
+        style={{
+          backgroundColor: 'var(--win-silver)',
+          borderTop: '1px solid var(--win-shadow)',
+        }}
+      >
+        {/* Left status segment */}
+        <div
+          className="flex items-center gap-1 px-2"
+          style={{
+            borderTop: '1px solid var(--win-dark)',
+            borderLeft: '1px solid var(--win-dark)',
+            borderRight: '1px solid var(--win-highlight)',
+            borderBottom: '1px solid var(--win-highlight)',
+          }}
+        >
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="8" cy="8" r="6" stroke="#1a5296" strokeWidth="1.5" fill="#d0e8f8" />
+            <ellipse cx="8" cy="8" rx="2.5" ry="6" stroke="#1a5296" strokeWidth="1" />
+            <line x1="2" y1="8" x2="14" y2="8" stroke="#1a5296" strokeWidth="1" />
+          </svg>
+          <span className="text-xs" style={{ fontSize: '10px' }}>Done</span>
+        </div>
+
+        <p className="text-center flex-1" style={{ fontSize: '10px' }}>
+          &copy; {currentYear} IEEE UOttawa. All rights reserved.
+        </p>
+
+        {/* Internet zone indicator */}
+        <div
+          className="flex items-center gap-1 px-2"
+          style={{
+            borderTop: '1px solid var(--win-dark)',
+            borderLeft: '1px solid var(--win-dark)',
+            borderRight: '1px solid var(--win-highlight)',
+            borderBottom: '1px solid var(--win-highlight)',
+          }}
+        >
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="8" cy="8" r="5" stroke="#5588cc" strokeWidth="1.5" fill="none" />
+            <path d="M8 3 L9 7 L13 7 L10 10 L11 14 L8 11 L5 14 L6 10 L3 7 L7 7 Z" fill="#5588cc" />
+          </svg>
+          <span style={{ fontSize: '10px' }}>Internet</span>
         </div>
       </div>
     </footer>

--- a/src/Header/Component.client.tsx
+++ b/src/Header/Component.client.tsx
@@ -13,7 +13,6 @@ interface HeaderClientProps {
 }
 
 export const HeaderClient: React.FC<HeaderClientProps> = ({ data }) => {
-  /* Storing the value in a useState to avoid hydration errors */
   const [theme, setTheme] = useState<string | null>(null)
   const { headerTheme, setHeaderTheme } = useHeaderTheme()
   const pathname = usePathname()
@@ -29,11 +28,116 @@ export const HeaderClient: React.FC<HeaderClientProps> = ({ data }) => {
   }, [headerTheme])
 
   return (
-    <header className="container relative z-20   " {...(theme ? { 'data-theme': theme } : {})}>
-      <div className="py-8 flex justify-between">
+    <header
+      className="relative z-20 w-full"
+      style={{ fontFamily: "'Tahoma','MS Sans Serif','Arial',sans-serif" }}
+      {...(theme ? { 'data-theme': theme } : {})}
+    >
+      {/* Windows 2000 title bar */}
+      <div
+        className="win-titlebar flex items-center justify-between px-2 py-1 select-none"
+        style={{
+          background: 'linear-gradient(to right, #0a246a 0%, #a6caf0 100%)',
+          minHeight: '22px',
+        }}
+      >
+        <div className="flex items-center gap-2">
+          {/* Globe icon like IE */}
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="8" cy="8" r="7" stroke="#7ab8e8" strokeWidth="1.5" fill="#1a5296" />
+            <ellipse cx="8" cy="8" rx="3" ry="7" stroke="#7ab8e8" strokeWidth="1" />
+            <line x1="1" y1="8" x2="15" y2="8" stroke="#7ab8e8" strokeWidth="1" />
+            <line x1="8" y1="1" x2="8" y2="15" stroke="#7ab8e8" strokeWidth="1" />
+          </svg>
+          <span className="text-white font-bold text-xs">IEEE UOttawa — Microsoft Internet Explorer</span>
+        </div>
+        {/* Win chrome buttons */}
+        <div className="flex items-center gap-1" aria-hidden="true">
+          {['_', '□', '✕'].map((ch) => (
+            <span
+              key={ch}
+              className="win-btn inline-flex items-center justify-center text-black font-bold"
+              style={{ width: '16px', height: '14px', fontSize: '9px', lineHeight: 1, padding: 0 }}
+            >
+              {ch}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Menu bar */}
+      <div
+        className="win-menubar flex items-center gap-0 px-1"
+        style={{ backgroundColor: 'var(--win-silver)', borderBottom: '1px solid var(--win-shadow)' }}
+      >
+        {['File', 'Edit', 'View', 'Favorites', 'Tools', 'Help'].map((item) => (
+          <button
+            key={item}
+            className="px-2 py-0.5 text-xs hover:bg-primary hover:text-white focus:outline-none"
+            style={{ fontFamily: "'Tahoma',sans-serif", fontSize: '11px', background: 'transparent' }}
+          >
+            {item}
+          </button>
+        ))}
+      </div>
+
+      {/* Address / nav toolbar */}
+      <div
+        className="flex items-center gap-2 px-2 py-1"
+        style={{
+          backgroundColor: 'var(--win-silver)',
+          borderBottom: '1px solid var(--win-shadow)',
+        }}
+      >
+        {/* Back / Forward / Refresh / Home */}
+        <div className="flex items-center gap-1">
+          {['◄', '►', '↺', '⌂'].map((icon) => (
+            <button key={icon} className="win-btn text-xs px-2 py-0.5" aria-label={icon}>
+              {icon}
+            </button>
+          ))}
+        </div>
+
+        {/* Address bar */}
+        <div className="flex items-center gap-1 flex-1">
+          <span className="text-xs font-bold" style={{ fontFamily: "'Tahoma',sans-serif" }}>Address</span>
+          <div
+            className="flex-1 flex items-center gap-1 px-1"
+            style={{
+              background: '#fff',
+              border: '2px solid',
+              borderColor: 'var(--win-dark) var(--win-highlight) var(--win-highlight) var(--win-dark)',
+              height: '22px',
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <circle cx="8" cy="8" r="6" stroke="#1a5296" strokeWidth="1.5" fill="#d0e8f8" />
+              <ellipse cx="8" cy="8" rx="2.5" ry="6" stroke="#1a5296" strokeWidth="1" />
+              <line x1="2" y1="8" x2="14" y2="8" stroke="#1a5296" strokeWidth="1" />
+            </svg>
+            <span className="text-xs" style={{ fontFamily: "'Tahoma',sans-serif", color: '#000' }}>
+              http://www.ieee.uottawa.ca/en
+            </span>
+          </div>
+          <button className="win-btn text-xs px-3 py-0.5">Go</button>
+        </div>
+
+        {/* Logo */}
         <Link href="/">
           <Logo loading="eager" priority={true} className="invert dark:invert-0" />
         </Link>
+      </div>
+
+      {/* Links toolbar (main nav) */}
+      <div
+        className="flex items-center gap-0 px-2 py-0.5"
+        style={{
+          backgroundColor: 'var(--win-silver)',
+          borderBottom: '2px solid var(--win-shadow)',
+        }}
+      >
+        <span className="text-xs font-bold mr-2" style={{ fontFamily: "'Tahoma',sans-serif" }}>Links</span>
+        <div className="w-px h-4 mx-1" style={{ background: 'var(--win-shadow)' }} aria-hidden="true" />
         <HeaderNav data={data} />
       </div>
     </header>

--- a/src/Header/Nav/index.tsx
+++ b/src/Header/Nav/index.tsx
@@ -16,16 +16,31 @@ export const HeaderNav: React.FC<{ data: HeaderType; documentYears?: (string | n
   const navItems = data?.navItems || []
 
   return (
-    <nav className="flex gap-3 items-center">
-      {navItems.map(({ link }, i) => {
-        return <CMSLink key={i} {...link} appearance="link" />
-      })}
+    <nav
+      className="flex items-center gap-0 flex-wrap"
+      style={{ fontFamily: "'Tahoma','MS Sans Serif','Arial',sans-serif" }}
+    >
+      {navItems.map(({ link }, i) => (
+        <CMSLink
+          key={i}
+          {...link}
+          appearance="link"
+          className="px-2 py-0.5 text-xs text-foreground underline hover:bg-primary hover:text-white focus:outline-none"
+        />
+      ))}
+
+      <div className="w-px h-4 mx-1" style={{ background: 'var(--win-shadow)' }} aria-hidden="true" />
 
       <LocaleSwitcher />
 
-      <Link href="/search">
+      <Link
+        href="/search"
+        className="win-btn inline-flex items-center gap-1 ml-1 text-xs"
+        style={{ padding: '2px 6px' }}
+      >
+        <SearchIcon className="w-3 h-3" aria-hidden="true" />
         <span className="sr-only">Search</span>
-        <SearchIcon className="w-5 text-primary" />
+        <span aria-hidden="true">Search</span>
       </Link>
     </nav>
   )

--- a/src/app/(frontend)/[locale]/globals.css
+++ b/src/app/(frontend)/[locale]/globals.css
@@ -2,6 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ── Windows 2000 / MS Office 2000 Design System ── */
+@import url('https://fonts.googleapis.com/css2?family=Tahoma:wght@400;700&display=swap');
+
 @layer base {
   h1,
   h2,
@@ -14,73 +17,94 @@
   }
 
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* Win2k color palette */
+    --background: 210 17% 86%;        /* #d4d0c8  classic silver */
+    --foreground: 0 0% 0%;            /* black text */
 
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card: 210 17% 86%;              /* same silver for panels */
+    --card-foreground: 0 0% 0%;
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover: 210 17% 86%;
+    --popover-foreground: 0 0% 0%;
 
-    --primary: 225 93% 16%;
+    --primary: 213 62% 38%;           /* Win2k title bar blue #2356a5 */
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 208 80% 45%;
+    --secondary: 180 42% 38%;         /* teal accent */
     --secondary-foreground: 0 0% 100%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 210 10% 78%;             /* slightly darker silver */
+    --muted-foreground: 0 0% 40%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 180 42% 38%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 240 6% 80%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --border: 210 17% 86%;
+    --input: 0 0% 100%;
+    --ring: 213 62% 38%;
 
-    --radius: 0.2rem;
+    --radius: 0rem;   /* no rounding in Win2k */
 
-    --success: 196 52% 74%;
-    --warning: 34 89% 85%;
-    --error: 10 100% 86%;
+    --success: 120 40% 50%;
+    --warning: 34 89% 60%;
+    --error: 0 80% 55%;
+
+    /* Win2k bevel helpers (used via CSS directly) */
+    --win-highlight: #ffffff;
+    --win-light: #e0ddd6;
+    --win-shadow: #808080;
+    --win-dark: #404040;
+    --win-silver: #d4d0c8;
+    --win-title: #0a246a;
+    --win-title-end: #a6caf0;
+    --win-statusbar: #d4d0c8;
   }
 
+  /* Keep dark theme functional but also Win2k-flavored */
   [data-theme='dark'] {
-    --background: 0 0% 0%;
-    --foreground: 210 40% 98%;
+    --background: 210 10% 18%;
+    --foreground: 210 40% 90%;
 
-    --card: 0 0% 4%;
-    --card-foreground: 210 40% 98%;
+    --card: 210 10% 22%;
+    --card-foreground: 210 40% 90%;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 210 10% 22%;
+    --popover-foreground: 210 40% 90%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 213 62% 55%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 180 42% 45%;
+    --secondary-foreground: 0 0% 100%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 210 10% 28%;
+    --muted-foreground: 210 20% 60%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 180 42% 45%;
+    --accent-foreground: 0 0% 100%;
 
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 62.8% 40%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 0, 0%, 15%, 0.8;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --border: 210 10% 30%;
+    --input: 210 10% 28%;
+    --ring: 213 62% 55%;
 
-    --success: 196 100% 14%;
-    --warning: 34 51% 25%;
-    --error: 10 39% 43%;
+    --success: 120 40% 35%;
+    --warning: 34 51% 35%;
+    --error: 0 50% 45%;
+
+    --win-highlight: #4a5060;
+    --win-light: #3a4050;
+    --win-shadow: #1a1e28;
+    --win-dark: #0a0e18;
+    --win-silver: #2a3040;
+    --win-title: #1a3a8a;
+    --win-title-end: #3a6ab0;
+    --win-statusbar: #2a3040;
   }
 }
 
@@ -90,6 +114,104 @@
   }
   body {
     @apply bg-background text-foreground min-h-[100vh] flex flex-col;
+    font-family: 'Tahoma', 'MS Sans Serif', 'Arial', sans-serif;
+    font-size: 11px;
+  }
+}
+
+/* ── Win2k Utility Classes ── */
+@layer utilities {
+  /* Raised 3-D bevel (like buttons, panels) */
+  .win-raised {
+    border-top: 2px solid var(--win-highlight);
+    border-left: 2px solid var(--win-highlight);
+    border-right: 2px solid var(--win-dark);
+    border-bottom: 2px solid var(--win-dark);
+  }
+
+  /* Sunken 3-D bevel (like insets, active) */
+  .win-sunken {
+    border-top: 2px solid var(--win-dark);
+    border-left: 2px solid var(--win-dark);
+    border-right: 2px solid var(--win-highlight);
+    border-bottom: 2px solid var(--win-highlight);
+  }
+
+  /* Outer + inner bevel combo */
+  .win-panel {
+    border-top: 1px solid var(--win-highlight);
+    border-left: 1px solid var(--win-highlight);
+    border-right: 1px solid var(--win-shadow);
+    border-bottom: 1px solid var(--win-shadow);
+    outline: 1px solid var(--win-light);
+    outline-offset: -1px;
+  }
+
+  /* Classic Win2k button */
+  .win-btn {
+    background-color: var(--win-silver);
+    border-top: 2px solid var(--win-highlight);
+    border-left: 2px solid var(--win-highlight);
+    border-right: 2px solid var(--win-dark);
+    border-bottom: 2px solid var(--win-dark);
+    padding: 3px 10px;
+    font-family: 'Tahoma', sans-serif;
+    font-size: 11px;
+    cursor: pointer;
+  }
+
+  .win-btn:active {
+    border-top: 2px solid var(--win-dark);
+    border-left: 2px solid var(--win-dark);
+    border-right: 2px solid var(--win-highlight);
+    border-bottom: 2px solid var(--win-highlight);
+  }
+
+  /* Title bar gradient */
+  .win-titlebar {
+    background: linear-gradient(to right, var(--win-title), var(--win-title-end));
+    padding: 3px 6px;
+    color: white;
+    font-weight: bold;
+    font-size: 11px;
+    font-family: 'Tahoma', sans-serif;
+    user-select: none;
+  }
+
+  /* Menubar strip */
+  .win-menubar {
+    background-color: var(--win-silver);
+    border-bottom: 1px solid var(--win-shadow);
+    font-size: 11px;
+    font-family: 'Tahoma', sans-serif;
+  }
+
+  /* Status bar */
+  .win-statusbar {
+    background-color: var(--win-statusbar);
+    border-top: 1px solid var(--win-shadow);
+    font-size: 10px;
+    font-family: 'Tahoma', sans-serif;
+    padding: 2px 6px;
+  }
+
+  /* Classic scrollbar look (Webkit) */
+  ::-webkit-scrollbar { width: 16px; }
+  ::-webkit-scrollbar-track { background: var(--win-silver); }
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--win-silver);
+    border-top: 2px solid var(--win-highlight);
+    border-left: 2px solid var(--win-highlight);
+    border-right: 2px solid var(--win-dark);
+    border-bottom: 2px solid var(--win-dark);
+  }
+  ::-webkit-scrollbar-button {
+    background-color: var(--win-silver);
+    border-top: 2px solid var(--win-highlight);
+    border-left: 2px solid var(--win-highlight);
+    border-right: 2px solid var(--win-dark);
+    border-bottom: 2px solid var(--win-dark);
+    height: 16px;
   }
 }
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -94,8 +94,8 @@ const config = {
         warning: 'hsl(var(--warning))',
       },
       fontFamily: {
-        mono: ['var(--font-geist-mono)'],
-        sans: ['var(--font-geist-sans)'],
+        mono: ['var(--font-geist-mono)', 'Courier New', 'monospace'],
+        sans: ['Tahoma', 'MS Sans Serif', 'Arial', 'var(--font-geist-sans)', 'sans-serif'],
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## Windows 2000 Redesign

Re-skins the entire site in authentic Microsoft Windows 2000 / Internet Explorer 6 style.

### Changes

- **`globals.css`** — New Win2k color palette (silver `#d4d0c8`, title-bar blue `#0a246a→#a6caf0`, teal accent). Adds utility classes: `.win-raised`, `.win-sunken`, `.win-panel`, `.win-btn`, `.win-titlebar`, `.win-menubar`, `.win-statusbar`. Classic beveled scrollbars via `::-webkit-scrollbar`. Body font set to `Tahoma`.
- **`Header/Component.client.tsx`** — Full IE6 chrome: gradient title bar with globe icon and window chrome buttons (`_ □ ✕`), menu bar (File/Edit/View…), address toolbar with URL input and globe icon, links toolbar housing the main nav.
- **`Header/Nav/index.tsx`** — Nav links styled as underlined Win2k hyperlinks; Search becomes a beveled `win-btn`.
- **`Footer/Component.tsx`** — Win2k silver panel with sunken logo box, nav links, and a classic IE status bar (Done / Internet zone indicators).
- **`tailwind.config.mjs`** — `font-sans` updated to `Tahoma, MS Sans Serif, Arial`.