### PR TITLE
Disable local storage for media files

### DIFF
--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -42,8 +42,7 @@ export const Media: CollectionConfig = {
     },
   ],
   upload: {
-    // Upload to the public/media directory in Next.js making them publicly accessible even outside of Payload
-    staticDir: path.resolve(dirname, '../../public/media'),
+    disableLocalStorage: true,
     adminThumbnail: 'thumbnail',
     focalPoint: true,
     imageSizes: [


### PR DESCRIPTION
Note: we need to re-upload media files for this change to take in effect, as it only applies to new uploads.