### PR TITLE
fix(theme/docs,i18n): resolve light/dark inconsistency in documents; …

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -37,7 +37,12 @@
     "landingDescription": "Explore our archive of official documents, meeting minutes, and miscellaneous documents.",
     "landingDescriptionCont": " Select an academic year to view its specific documentation.",
     "noYears": "No archives have been published yet.",
-    "archiveLabel": "View Archives"
+    "archiveLabel": "View Archives",
+    "archiveEyebrow": "Archive",
+    "allYears": "All Years",
+    "generalDocuments": "General Documents",
+    "meetingMinutes": "Meeting Minutes",
+    "otherDocuments": "Other Documents"
   },
   "committee": {
     "pageTitle": "Committees",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -38,7 +38,12 @@
     "landingDescription": "Explorez notre archive de documents officiels, les procès-verbaux de réunions et les documents divers.",
     "landingDescriptionCont": " Sélectionnez une année académique pour voir sa documentation spécifique.",
     "noYears": "Aucune archive n'a encore été publiée.",
-    "archiveLabel": "Voir les Archives"
+    "archiveLabel": "Voir les Archives",
+    "archiveEyebrow": "Archive",
+    "allYears": "Toutes les années",
+    "generalDocuments": "Documents généraux",
+    "meetingMinutes": "Procès-verbaux",
+    "otherDocuments": "Autres documents"
   },
   "committee": {
     "pageTitle": "Comités",

--- a/src/app/(frontend)/[locale]/documents/[year]/page.tsx
+++ b/src/app/(frontend)/[locale]/documents/[year]/page.tsx
@@ -1,7 +1,7 @@
 import { getPayload } from 'payload'
 import configPromise from '@payload-config'
 import { notFound } from 'next/navigation'
-import { Doc, Config } from '@/payload-types'
+import { Config } from '@/payload-types'
 import { YearlyDocument } from '../_components/YearlyDocument'
 
 export async function generateStaticParams() {
@@ -46,11 +46,11 @@ export default async function DocsPage({ params: paramsPromise }: Args) {
     limit: 1,
   })
 
-  const docs = result.docs[0] as Doc
+  const doc = result.docs[0]
 
-  if (!docs) {
+  if (!doc) {
     return notFound()
   }
 
-  return YearlyDocument(docs)
+  return await YearlyDocument(doc, locale)
 }

--- a/src/app/(frontend)/[locale]/documents/_components/YearlyDocument.tsx
+++ b/src/app/(frontend)/[locale]/documents/_components/YearlyDocument.tsx
@@ -1,4 +1,19 @@
-import { Doc } from '@/payload-types'
+import Link from 'next/link'
+import { ArrowLeft, ArrowUpRight } from 'lucide-react'
+import { getTranslations } from 'next-intl/server'
+import { Config, Doc } from '@/payload-types'
+import {
+  Eyebrow,
+  IndexNumber,
+  SectionShell,
+  themeKickerText,
+  themeMutedText,
+  themeRule,
+  type BlockTheme,
+} from '@/blocks/_shared'
+import { cn } from '@/utilities/ui'
+
+type DocItem = NonNullable<Doc['meetingMinutes']>[number]
 
 const formatUrl = (url?: string) => {
   if (!url) return '#'
@@ -6,91 +21,147 @@ const formatUrl = (url?: string) => {
   return `https://${url}`
 }
 
-const formatDate = (dateString?: string | null) => {
+const formatDate = (dateString: string | null | undefined, locale: Config['locale']) => {
   if (!dateString) return null
-  return new Date(dateString).toISOString().split('T')[0]
+  return new Intl.DateTimeFormat(locale ?? 'en', { dateStyle: 'medium' }).format(
+    new Date(dateString),
+  )
 }
 
-export function YearlyDocument(docs: Doc) {
+type DocumentSectionProps = {
+  label: string
+  items: DocItem[]
+  theme: BlockTheme
+  locale: Config['locale']
+}
+
+const DocumentSection = ({ label, items, theme, locale }: DocumentSectionProps) => {
+  const total = items.length
+
   return (
-    <div className="max-w-4xl mx-auto w-full px-4 sm:px-6 space-y-12 py-8">
-      {(docs.generalDocuments ?? []).length > 0 && (
-        <section>
-          <h2 className="text-3xl font-extrabold text-gray-900 tracking-tight mb-6">
-            General Documents
-          </h2>
+    <section className="space-y-8">
+      <Eyebrow theme={theme}>{label}</Eyebrow>
 
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {docs.generalDocuments?.map((doc) => (
-              <a
-                key={doc.id || doc.name}
-                href={formatUrl(doc.googleDocsUrl)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block p-4 bg-white border border-gray-200 hover:border-[#03164f] hover:shadow-sm rounded-xl transition-all duration-200"
-              >
-                <h3 className="text-lg font-bold text-gray-900 mb-1">{doc.name}</h3>
-                {doc.description && (
-                  <p className="text-sm text-gray-500 leading-snug">{doc.description}</p>
-                )}
-              </a>
-            ))}
-          </div>
-        </section>
-      )}
-      {(docs.meetingMinutes ?? []).length > 0 && (
-        <section>
-          <h2 className="text-3xl font-extrabold text-gray-900 tracking-tight mb-6">
-            Meeting Minutes
-          </h2>
+      <div className={cn('h-px w-full', themeRule[theme])} />
 
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {docs.meetingMinutes?.map((minute) => (
-              <a
-                key={minute.id || minute.name}
-                href={formatUrl(minute.googleDocsUrl)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block p-4 bg-white border border-gray-200 hover:border-[#03164f] hover:shadow-sm rounded-xl transition-all duration-200"
-              >
-                <h3 className="text-lg font-bold text-gray-900">{minute.name}</h3>
-                {minute.meetingDate && (
-                  <p className="text-xs font-semibold text-[#03164f]/80 mt-1 uppercase tracking-wider">
-                    {formatDate(minute.meetingDate)}
+      <ul role="list" className="divide-y divide-foreground/10">
+        {items.map((item, index) => (
+          <li
+            key={item.id || item.name}
+            className="group relative focus-within:ring-2 focus-within:ring-inset focus-within:ring-primary"
+          >
+            <a
+              href={formatUrl(item.googleDocsUrl)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute inset-0 z-10 focus-visible:outline-none"
+            >
+              <span className="sr-only">{item.name}</span>
+            </a>
+            <div className="grid grid-cols-[auto_1fr_auto] items-baseline gap-x-6 gap-y-2 py-7 transition-all duration-300 group-hover:bg-foreground/[0.025] group-hover:pl-3">
+              <IndexNumber
+                value={index + 1}
+                total={total}
+                theme={theme}
+                className="self-center"
+              />
+              <div className="space-y-1.5">
+                <h3 className="text-balance text-xl font-medium leading-snug tracking-tight transition-colors group-hover:text-primary md:text-2xl">
+                  {item.name}
+                </h3>
+                {item.meetingDate && (
+                  <p
+                    className={cn(
+                      'font-mono text-[0.7rem] uppercase tracking-[0.22em]',
+                      themeKickerText[theme],
+                    )}
+                  >
+                    {formatDate(item.meetingDate, locale)}
                   </p>
                 )}
-                {minute.description && (
-                  <p className="text-sm text-gray-500 mt-2 leading-snug">{minute.description}</p>
+                {item.description && (
+                  <p className={cn('max-w-2xl text-sm leading-relaxed', themeMutedText[theme])}>
+                    {item.description}
+                  </p>
                 )}
-              </a>
-            ))}
-          </div>
-        </section>
-      )}{' '}
-      {(docs.otherDocuments ?? []).length > 0 && (
-        <section>
-          <h2 className="text-3xl font-extrabold text-gray-900 tracking-tight mb-6">
-            Other Documents
-          </h2>
+              </div>
+              <ArrowUpRight
+                aria-hidden="true"
+                className="h-5 w-5 self-center text-primary transition-all duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
 
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {docs.otherDocuments?.map((doc) => (
-              <a
-                key={doc.id || doc.name}
-                href={formatUrl(doc.googleDocsUrl)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block p-4 bg-white border border-gray-200 hover:border-[#03164f] hover:shadow-sm rounded-xl transition-all duration-200"
-              >
-                <h3 className="text-lg font-bold text-gray-900 mb-1">{doc.name}</h3>
-                {doc.description && (
-                  <p className="text-sm text-gray-500 leading-snug">{doc.description}</p>
-                )}
-              </a>
-            ))}
+export async function YearlyDocument(docs: Doc, locale: Config['locale']) {
+  const theme: BlockTheme = 'default'
+  const general = docs.generalDocuments ?? []
+  const minutes = docs.meetingMinutes ?? []
+  const other = docs.otherDocuments ?? []
+
+  const t = await getTranslations({ locale: locale ?? 'en', namespace: 'docs' })
+
+  const isEmpty = general.length === 0 && minutes.length === 0 && other.length === 0
+
+  return (
+    <SectionShell theme={theme} padding="py-20 md:py-24">
+      <header className="mb-12 grid gap-6 md:mb-16 md:grid-cols-12 md:items-end md:gap-10">
+        <div className="space-y-5 md:col-span-7">
+          <Eyebrow theme={theme}>{t('archiveEyebrow')}</Eyebrow>
+          <h1 className="text-balance text-4xl font-medium leading-[1.05] tracking-tight sm:text-5xl md:text-[3rem]">
+            {docs.year}
+          </h1>
+        </div>
+        <div className="md:col-span-5 md:flex md:justify-end">
+          <Link
+            href="/documents"
+            className="inline-flex items-center gap-2 font-mono text-[0.72rem] uppercase tracking-[0.22em] text-primary transition-colors hover:text-secondary"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            {t('allYears')}
+          </Link>
+        </div>
+      </header>
+
+      {isEmpty ? (
+        <>
+          <div className={cn('h-px w-full', themeRule[theme])} />
+          <div className={cn('py-20 text-center text-sm', themeMutedText[theme])}>
+            {t('noDocuments')}
           </div>
-        </section>
+        </>
+      ) : (
+        <div className="space-y-16 md:space-y-20">
+          {general.length > 0 && (
+            <DocumentSection
+              label={t('generalDocuments')}
+              items={general}
+              theme={theme}
+              locale={locale}
+            />
+          )}
+          {minutes.length > 0 && (
+            <DocumentSection
+              label={t('meetingMinutes')}
+              items={minutes}
+              theme={theme}
+              locale={locale}
+            />
+          )}
+          {other.length > 0 && (
+            <DocumentSection
+              label={t('otherDocuments')}
+              items={other}
+              theme={theme}
+              locale={locale}
+            />
+          )}
+        </div>
       )}
-    </div>
+    </SectionShell>
   )
 }

--- a/src/app/(frontend)/[locale]/documents/_components/YearlyDocument.tsx
+++ b/src/app/(frontend)/[locale]/documents/_components/YearlyDocument.tsx
@@ -44,7 +44,7 @@ const DocumentSection = ({ label, items, theme, locale }: DocumentSectionProps) 
 
       <div className={cn('h-px w-full', themeRule[theme])} />
 
-      <ul role="list" className="divide-y divide-foreground/10">
+      <ul role="list" className="divide-y divide-foreground/20">
         {items.map((item, index) => (
           <li
             key={item.id || item.name}

--- a/src/app/(frontend)/[locale]/documents/page.tsx
+++ b/src/app/(frontend)/[locale]/documents/page.tsx
@@ -1,9 +1,18 @@
 import Link from 'next/link'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
-import { FolderArchive, ArrowRight } from 'lucide-react'
+import { ArrowUpRight } from 'lucide-react'
 import { getTranslations } from 'next-intl/server'
-import type { Event, Config } from '@/payload-types'
+import type { Config } from '@/payload-types'
+import {
+  Eyebrow,
+  IndexNumber,
+  SectionShell,
+  themeMutedText,
+  themeRule,
+  type BlockTheme,
+} from '@/blocks/_shared'
+import { cn } from '@/utilities/ui'
 
 type Args = {
   params: Promise<{ locale: Config['locale'] }>
@@ -25,47 +34,64 @@ export default async function DocumentsPage({ params: paramsPromise }: Args) {
     namespace: 'docs',
   })
 
-  return (
-    <main className="max-w-7xl mx-auto px-4 sm: px-6 lg:px-8 py-16">
-      <header className="max-w-3xl mx-auto text-center mb-16">
-        <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight text-gray-900 mb-6">
-          {t('title')}
-        </h1>
+  const theme: BlockTheme = 'default'
+  const total = docs.length
 
-        <p className="text-lg text-gray-600 leading-relaxed">
-          {t('landingDescription')}
-          {t('landingDescriptionCont')}
-        </p>
+  return (
+    <SectionShell theme={theme} padding="py-20 md:py-28">
+      <header className="mb-12 grid gap-6 md:mb-16 md:grid-cols-12 md:items-end md:gap-10">
+        <div className="space-y-5 md:col-span-7">
+          <Eyebrow theme={theme}>{t('archiveLabel') || 'View Archives'}</Eyebrow>
+          <h1 className="text-balance text-4xl font-medium leading-[1.05] tracking-tight sm:text-5xl md:text-[3.25rem]">
+            {t('title')}
+          </h1>
+        </div>
+        <div className="md:col-span-5">
+          <p className={cn('text-base leading-relaxed', themeMutedText[theme])}>
+            {t('landingDescription')}
+            {t('landingDescriptionCont')}
+          </p>
+        </div>
       </header>
 
+      <div className={cn('h-px w-full', themeRule[theme])} />
+
       {docs.length === 0 ? (
-        <div className="text-center p-12 border-2 border-dashed border-gray-200 rounded-2xl text-gray-500 bg-gray-50">
+        <div className={cn('py-20 text-center text-sm', themeMutedText[theme])}>
           {t('noYears')}
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {docs.map((doc) => (
-            <Link
+        <ul role="list" className="divide-y divide-foreground/10">
+          {docs.map((doc, index) => (
+            <li
               key={doc.id}
-              href={`/documents/${doc.year}`}
-              className="group flex items-center justify-between p-8 bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-lg hover:border-[#03164f]/50 hover:-translate-y-1 transition-all duration-300"
+              className="group relative focus-within:ring-2 focus-within:ring-inset focus-within:ring-primary"
             >
-              <div className="flex flex-col pr-4">
-                <span className="text-4xl font-extrabold text-gray-900 group-hover:text-[#03164f] tracking-tight transition-colors">
+              <Link
+                href={`/documents/${doc.year}`}
+                className="absolute inset-0 z-10 focus-visible:outline-none"
+              >
+                <span className="sr-only">{doc.year}</span>
+              </Link>
+              <div className="grid grid-cols-[auto_1fr_auto] items-center gap-x-6 gap-y-2 py-8 transition-all duration-300 group-hover:bg-foreground/[0.025] group-hover:pl-3 md:py-10">
+                <IndexNumber
+                  value={index + 1}
+                  total={total}
+                  theme={theme}
+                  className="self-center"
+                />
+                <span className="text-balance text-4xl font-medium leading-none tracking-tight transition-colors group-hover:text-primary md:text-5xl">
                   {doc.year}
                 </span>
-                <span className="text-xs font-bold text-gray-400 mt-1.5 tracking-wider uppercase">
-                  {t('archiveLabel') || 'View Archives'}
-                </span>
+                <ArrowUpRight
+                  aria-hidden="true"
+                  className="h-5 w-5 self-center text-primary transition-all duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+                />
               </div>
-
-              <div className="w-14 h-14 shrink-0 rounded-full bg-slate-50 flex items-center justify-center group-hover:bg-[#03164f] transition-all duration-300">
-                <ArrowRight className="w-6 h-6 text-[#03164f] group-hover:text-white transition-colors duration-300 " />
-              </div>
-            </Link>
+            </li>
           ))}
-        </div>
+        </ul>
       )}
-    </main>
+    </SectionShell>
   )
 }

--- a/src/app/(frontend)/[locale]/documents/page.tsx
+++ b/src/app/(frontend)/[locale]/documents/page.tsx
@@ -61,7 +61,7 @@ export default async function DocumentsPage({ params: paramsPromise }: Args) {
           {t('noYears')}
         </div>
       ) : (
-        <ul role="list" className="divide-y divide-foreground/10">
+        <ul role="list" className="divide-y divide-foreground/20">
           {docs.map((doc, index) => (
             <li
               key={doc.id}

--- a/src/blocks/QuickLinks/Component.tsx
+++ b/src/blocks/QuickLinks/Component.tsx
@@ -95,7 +95,7 @@ export const QuickLinksBlock: React.FC<QuickLinksBlockProps> = ({
         ) : (
           <ul
             role="list"
-            className={cn('divide-y', t === 'dark' ? 'divide-white/10' : 'divide-foreground/10')}
+            className={cn('divide-y', t === 'dark' ? 'divide-white/20' : 'divide-foreground/20')}
           >
             {links.map((item, index) => (
               <li

--- a/src/blocks/_shared.tsx
+++ b/src/blocks/_shared.tsx
@@ -21,8 +21,8 @@ export const themeRule: Record<BlockTheme, string> = {
 }
 
 export const themeMutedText: Record<BlockTheme, string> = {
-  default: 'text-muted-foreground',
-  muted: 'text-muted-foreground',
+  default: 'text-foreground',
+  muted: 'text-foreground',
   accent: 'text-foreground/70',
   dark: 'text-white/65',
 }

--- a/src/blocks/_shared.tsx
+++ b/src/blocks/_shared.tsx
@@ -14,10 +14,10 @@ export const sectionShellClasses: Record<BlockTheme, string> = {
 }
 
 export const themeRule: Record<BlockTheme, string> = {
-  default: 'bg-foreground/15',
-  muted: 'bg-foreground/15',
+  default: 'bg-foreground/25',
+  muted: 'bg-foreground/25',
   accent: 'bg-primary/25',
-  dark: 'bg-white/15',
+  dark: 'bg-white/25',
 }
 
 export const themeMutedText: Record<BlockTheme, string> = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,7 @@
       ],
       "@/*": [
         "./src/*"
-      ],
+      ]
     }
   },
   "include": [
@@ -43,9 +43,10 @@
     "redirects.js",
     "next-env.d.ts",
     "next.config.js",
-    "next-sitemap.config.cjs"
+    "next-sitemap.config.cjs",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"
-  ],
+  ]
 }


### PR DESCRIPTION
What this PR does:
- Resolves the light/dark UI inconsistency in documents, things worked fine in light mode, but not in dark mode.
- Decided to just apply the same theme I applied to all of the blocks because why not
- There were i18n issues with the year-specific document page, I fixed those
- Couldn't reproduce the "Year specific endpoint is broken" issue, both in local and remote. 
Screenshots:
<img width="2785" height="1592" alt="image" src="https://github.com/user-attachments/assets/b48e7c26-8a52-4eb1-b214-047f987a8c1f" />
<img width="2785" height="1592" alt="image" src="https://github.com/user-attachments/assets/8e318e90-9bb3-4d7d-ad5d-da74f140236a" />
<img width="2785" height="1592" alt="image" src="https://github.com/user-attachments/assets/a01ae218-8117-47a4-a863-1e242d72a6b2" />
<img width="2785" height="3784" alt="image" src="https://github.com/user-attachments/assets/5c2d734c-502f-4e2c-9590-d158691111f9" />
<img width="2785" height="3784" alt="image" src="https://github.com/user-attachments/assets/1bbaca25-0680-446c-9741-2a837bd8722f" />
<img width="2785" height="3752" alt="image" src="https://github.com/user-attachments/assets/29528755-8f10-43a8-8a72-b7bee2855513" />
Yeah idk i'm still not sure about the design but I'll try seeing if I can reproduce the broken endpoint issue on the preview env.

Idek how tsconfig.ts got changed, i created the branch and it was already like that, but oh well.
