### PR TITLE
build(compose): Add Vercel Blob Emulator to docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,17 @@
-# Database connection string, for local development it should match the one in docker-compose.yml
-POSTGRES_URL=postgresql://127.0.0.1:5432/<your-local-db-name>
+# Database connection string, for local development it should match docker-compose.yml
+POSTGRES_URL=postgresql://postgres@127.0.0.1:54320/payload
 # Used to encrypt JWT tokens, for local development you can use any long random string
 PAYLOAD_SECRET=<your-payload-secret>
 # Used to validate preview requests, for local development you can use any long random string
 PREVIEW_SECRET=<your-preview-secret>
+
+# Local Vercel Blob emulator. Production values are provided by Vercel.
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_emulator_local
+VERCEL_BLOB_API_URL=http://localhost:3100/api/blob
+NEXT_PUBLIC_VERCEL_BLOB_API_URL=http://localhost:3100/api/blob
+STORAGE_VERCEL_BLOB_BASE_URL=http://localhost:3100
+VERCEL_BLOB_RETRIES=0
+VERCEL_BLOB_CALLBACK_URL=http://localhost:3000
 
 
 # Used to configure CORS, format links and more. No trailing slash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the official website of the IEEE uOttawa Student Branch. It serves as a 
 - To make changes to the content of the production website, use the Payload admin panel https://ieeeuottawa-v3.vercel.app/admin. Since we are using a CMS (Content Management System), there is no need to make content changes through code. **Caution: any changes made here will be reflected on the live website immediately, so please ensure that you have the proper permissions and that you are making intentional changes.**
 - The website is [deployed serverless on Vercel](https://vercel.com/ieee-uottawa-webmaster/ieeeuottawa-v3). Only the webmaster account has modification permissions, but any contributor can view deployments and their logs. Please reach out to the webmaster if you would like to be added as a viewer to the project on Vercel.
 - In production, Payload uses Neon (a Postgres-based cloud database) to store all of the content for the website, and Vercel Blob Storage to store all of the media assets. Both of these services are integrated into Vercel and were automatically set up when the project was deployed. **Please ensure a proper backup exists before making any destructive changes to the production database or blob storage, as data loss can occur.**
-- For local development, every developer can run their own instance of the database using Docker. This creates a distinct environment where changes won't affect what is currently deployed. Setup instructions are explained in [Getting Started](#getting-started).
+- For local development, every developer can run their own instance of the database and the [Vercel Blob Emulator](https://github.com/payloadcms/vercel-blob-emulator) using Docker. This creates a distinct environment where changes won't affect what is currently deployed. Setup instructions are explained in [Getting Started](#getting-started).
 
 ## Useful links 🔗
 
@@ -60,7 +60,7 @@ git clone https://github.com/ieee-webmaster/ieeeuottawa-v3.git
 `PREVIEW_SECRET`: Set `<your-preview-secret>` to a long random string
 <br>
 
-3. Start a local instance of the Postgres database using Docker.
+3. Start a local instance of the Postgres database and Vercel Blob Emulator using Docker.
 
 ```bash
 docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   postgres:
     image: postgres
@@ -11,3 +9,17 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     env_file:
       - .env
+
+  vercel-blob:
+    image: ghcr.io/payloadcms/vercel-blob-emulator:latest
+    ports:
+      - '3100:3000'
+    env_file:
+      - .env
+    environment:
+      EMULATOR_BASE_URL: http://localhost:3100
+    volumes:
+      - vercel_blob_data:/data
+
+volumes:
+  vercel_blob_data:

--- a/next.config.js
+++ b/next.config.js
@@ -5,23 +5,28 @@ import redirects from './redirects.js'
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts')
 
-const NEXT_PUBLIC_SERVER_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
-  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-  : undefined || process.env.__NEXT_PRIVATE_ORIGIN || 'http://localhost:3000'
+const NEXT_PUBLIC_SERVER_URL =
+  process.env.NEXT_PUBLIC_SERVER_URL ||
+  (process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : process.env.__NEXT_PRIVATE_ORIGIN || 'http://localhost:3000')
+
+const remotePatterns = [NEXT_PUBLIC_SERVER_URL, process.env.STORAGE_VERCEL_BLOB_BASE_URL]
+  .filter(Boolean)
+  .map((item) => {
+    const url = new URL(item)
+
+    return {
+      hostname: url.hostname,
+      port: url.port,
+      protocol: url.protocol.replace(':', ''),
+    }
+  })
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    remotePatterns: [
-      ...[NEXT_PUBLIC_SERVER_URL /* 'https://example.com' */].map((item) => {
-        const url = new URL(item)
-
-        return {
-          hostname: url.hostname,
-          protocol: url.protocol.replace(':', ''),
-        }
-      }),
-    ],
+    remotePatterns,
   },
   reactStrictMode: true,
   redirects,


### PR DESCRIPTION
- Adds the [Vercel Blob Emulator](https://github.com/payloadcms/vercel-blob-emulator) to the docker-compose.yml file
- Updates .env.example and the README
- Modifies next.config.js to work properly with the new setup.