### PR TITLE
fix: skip nextjs img optimizer, use payload directly

### DIFF
--- a/src/app/(frontend)/[locale]/committee/[year]/page.tsx
+++ b/src/app/(frontend)/[locale]/committee/[year]/page.tsx
@@ -3,14 +3,13 @@ import type { Metadata } from 'next'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 import { notFound } from 'next/navigation'
-import Image from 'next/image'
 import { ArrowLeft, Mail, Linkedin, UserRound } from 'lucide-react'
 import { getTranslations } from 'next-intl/server'
 import type { Committee, Team, Person, Media, Config } from '@/payload-types'
 import { generateStaticMeta } from '@/utilities/generateMeta'
 import { Link } from '@/i18n/navigation'
 import { Eyebrow, SectionShell, themeRule } from '@/blocks/_shared'
-import { getMediaUrl } from '@/utilities/getMediaUrl'
+import { Media as MediaComponent } from '@/components/Media'
 
 type Args = {
   params: Promise<{ year: string; locale: Config['locale'] }>
@@ -63,10 +62,6 @@ export default async function CommitteePage({ params }: Args) {
     .filter((section) => section.data.length > 0)
 
   const hasNoData = sections.length === 0
-  const coverImageSrc = coverImage?.url
-    ? getMediaUrl(coverImage.url, coverImage.updatedAt)
-    : undefined
-
   return (
     <SectionShell theme="default" padding="pt-20 pb-20 md:pt-28 md:pb-28">
       <header className="mb-10 grid gap-8 md:mb-14 md:grid-cols-12 md:items-end md:gap-10">
@@ -90,15 +85,17 @@ export default async function CommitteePage({ params }: Args) {
         </div>
       </header>
 
-      {coverImageSrc ? (
+      {coverImage ? (
         <div className="relative mb-16 aspect-[4/3] overflow-hidden bg-foreground/[0.04] sm:aspect-video md:mb-24 lg:aspect-[21/9]">
-          <Image
-            src={coverImageSrc}
-            alt={coverImage?.alt || `${committee.Year} ${t('title')}`}
+          <MediaComponent
             fill
+            htmlElement={null}
+            resource={coverImage}
+            alt={coverImage?.alt || `${committee.Year} ${t('title')}`}
             priority
-            className="object-cover"
-            sizes="(max-width: 768px) 100vw, 1360px"
+            imgClassName="object-cover"
+            pictureClassName="absolute inset-0"
+            sizesPreset="content"
           />
         </div>
       ) : (
@@ -138,21 +135,23 @@ export default async function CommitteePage({ params }: Args) {
               <div className="grid grid-cols-2 gap-x-4 gap-y-12 sm:gap-x-6 md:grid-cols-3 lg:grid-cols-4 lg:gap-x-8 lg:gap-y-16">
                 {section.data.map((member) => {
                   const person = member.person as Person
-                  const headshot = person.headshot as Media | undefined
-                  const headshotSrc = headshot?.url
-                    ? getMediaUrl(headshot.url, headshot.updatedAt)
-                    : undefined
+                  const headshot =
+                    person.headshot && typeof person.headshot === 'object'
+                      ? person.headshot
+                      : undefined
 
                   return (
                     <article key={member.id} className="group min-w-0">
                       <div className="relative aspect-[4/5] overflow-hidden bg-foreground/[0.04]">
-                        {headshotSrc ? (
-                          <Image
-                            src={headshotSrc}
-                            alt={person.fullName}
+                        {headshot ? (
+                          <MediaComponent
                             fill
-                            className="object-cover transition-transform duration-700 ease-out group-hover:scale-[1.035]"
-                            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+                            htmlElement={null}
+                            resource={headshot}
+                            alt={person.fullName}
+                            imgClassName="object-cover transition-transform duration-700 ease-out group-hover:scale-[1.035]"
+                            pictureClassName="absolute inset-0"
+                            sizesPreset="portraitGrid"
                           />
                         ) : (
                           <div className="flex h-full w-full items-center justify-center">

--- a/src/app/(frontend)/[locale]/events/_components/EventCard.tsx
+++ b/src/app/(frontend)/[locale]/events/_components/EventCard.tsx
@@ -1,9 +1,8 @@
 import { Link } from '@/i18n/navigation'
-import Image from 'next/image'
 import type { Event } from '@/payload-types'
-import { getMediaUrl } from '@/utilities/getMediaUrl'
 import type { Locale } from '@/i18n/routing'
 import { cn } from '@/utilities/ui'
+import { Media } from '@/components/Media'
 
 type Props = {
   event: Event
@@ -14,7 +13,6 @@ type Props = {
 
 export const EventCard = ({ event, locale, index, total }: Props) => {
   const heroMedia = event.heroImage && typeof event.heroImage === 'object' ? event.heroImage : null
-  const heroSrc = heroMedia?.url ? getMediaUrl(heroMedia.url, heroMedia.updatedAt) : null
   const eventDate = new Date(event.date)
   const validDate = !Number.isNaN(eventDate.valueOf())
   const month = validDate
@@ -40,20 +38,22 @@ export const EventCard = ({ event, locale, index, total }: Props) => {
         href={`/events/${encodeURIComponent(event.slug)}`}
         className="flex h-full flex-col gap-5"
       >
-        <div className="relative overflow-hidden">
-          {heroSrc ? (
-            <Image
-              src={heroSrc}
+        <div className="relative aspect-[4/3] overflow-hidden bg-foreground/5">
+          {heroMedia ? (
+            <Media
+              fill
+              htmlElement={null}
+              resource={heroMedia}
               alt={heroMedia?.alt || event.title || 'Event image'}
-              width={1200}
-              height={900}
-              className={cn(
-                'aspect-[4/3] w-full bg-foreground/5 object-cover',
+              imgClassName={cn(
+                'object-cover',
                 'transition-transform duration-700 ease-out group-hover:scale-[1.04]',
               )}
+              pictureClassName="absolute inset-0"
+              sizesPreset="third"
             />
           ) : (
-            <div className="flex aspect-[4/3] w-full items-center justify-center bg-foreground/[0.04]">
+            <div className="flex h-full w-full items-center justify-center bg-foreground/[0.04]">
               <span className="font-mono text-[0.7rem] uppercase tracking-[0.22em] text-foreground/40">
                 No image
               </span>

--- a/src/blocks/CardGrid/Component.tsx
+++ b/src/blocks/CardGrid/Component.tsx
@@ -46,12 +46,7 @@ export const CardGridBlock: React.FC<CardGridBlockProps> = ({
   const allSvgMedia = hasAnyMedia && (cards ?? []).every((c) => isSvgMedia(c.media))
   const variant: 'photo' | 'icon' | 'text' = !hasAnyMedia ? 'text' : allSvgMedia ? 'icon' : 'photo'
 
-  const mediaSize =
-    columns === '2'
-      ? '(max-width: 768px) 100vw, 50vw'
-      : columns === '4'
-        ? '(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 25vw'
-        : '(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw'
+  const mediaSizesPreset = columns === '2' ? 'half' : columns === '4' ? 'quarter' : 'third'
 
   const indexLabel = (i: number) => (
     <span
@@ -116,7 +111,7 @@ export const CardGridBlock: React.FC<CardGridBlockProps> = ({
                     imgClassName="object-cover"
                     pictureClassName="relative block h-full w-full"
                     resource={card.media}
-                    size={mediaSize}
+                    sizesPreset={mediaSizesPreset}
                   />
                   <span className="absolute left-3 top-3 rounded-sm bg-black/55 px-2 py-1 font-mono text-[0.7rem] tracking-[0.2em] text-white backdrop-blur-sm">
                     {String(index + 1).padStart(2, '0')}
@@ -140,7 +135,7 @@ export const CardGridBlock: React.FC<CardGridBlockProps> = ({
                       imgClassName="h-8 w-8 object-contain"
                       pictureClassName="relative block h-8 w-8"
                       resource={card.media}
-                      size="56px"
+                      sizesPreset="icon"
                     />
                   </div>
                   {indexLabel(index)}

--- a/src/blocks/CommitteeTeamMembers/Component.tsx
+++ b/src/blocks/CommitteeTeamMembers/Component.tsx
@@ -1,6 +1,5 @@
 import configPromise from '@payload-config'
 import { getLocale } from 'next-intl/server'
-import Image from 'next/image'
 import { Linkedin, Mail, User } from 'lucide-react'
 import React from 'react'
 import { getPayload } from 'payload'
@@ -15,6 +14,7 @@ import { resolveLocale } from '@/i18n/routing'
 import { getTranslations } from 'next-intl/server'
 import { cn } from '@/utilities/ui'
 import { SectionShell, Eyebrow, themeMutedText, themeRule, type BlockTheme } from '@/blocks/_shared'
+import { Media } from '@/components/Media'
 
 type TeamMember = NonNullable<NonNullable<Committee['teams']>[number]['members']>[number] & {
   teamName?: string
@@ -180,20 +180,23 @@ export const CommitteeTeamMembersBlock: React.FC<
                   .flatMap((section) => section.data)
                   .map((member) => {
                     const person = member.person as Person
-                    const headshot = person.headshot
-                      ? (person.headshot as { url?: string | null })
-                      : undefined
+                    const headshot =
+                      person.headshot && typeof person.headshot === 'object'
+                        ? person.headshot
+                        : undefined
 
                     return (
                       <div key={member.id} className="group flex flex-col items-center text-center">
                         <div className="relative mb-4 h-32 w-32 overflow-hidden rounded-full border border-foreground/10 bg-background transition-all md:h-40 md:w-40">
-                          {headshot?.url ? (
-                            <Image
-                              src={headshot.url}
-                              alt={person.fullName}
+                          {headshot ? (
+                            <Media
                               fill
-                              className="object-cover transition-transform duration-500"
-                              sizes="(max-width: 768px) 128px, 160px"
+                              htmlElement={null}
+                              resource={headshot}
+                              alt={person.fullName}
+                              imgClassName="object-cover transition-transform duration-500"
+                              pictureClassName="absolute inset-0"
+                              sizesPreset="avatar"
                             />
                           ) : (
                             <div className="flex h-full w-full items-center justify-center">

--- a/src/blocks/Gallery/Component.tsx
+++ b/src/blocks/Gallery/Component.tsx
@@ -50,12 +50,8 @@ export const GalleryBlockComponent: React.FC<GalleryBlockProps> = ({
             const featureSpan =
               layout === 'featureMix' && index === 0 ? 'md:col-span-2 md:row-span-2' : undefined
             const revealOnInteraction = Boolean(item.enableLink)
-            const mediaSize =
-              layout === 'grid'
-                ? '(max-width: 768px) 50vw, 33vw'
-                : featureSpan
-                  ? '(max-width: 768px) 50vw, 50vw'
-                  : '(max-width: 768px) 50vw, 25vw'
+            const mediaSizesPreset =
+              layout === 'grid' ? 'galleryThird' : featureSpan ? 'galleryHalf' : 'galleryQuarter'
 
             return (
               <figure
@@ -73,7 +69,7 @@ export const GalleryBlockComponent: React.FC<GalleryBlockProps> = ({
                     imgClassName="object-cover transition-transform duration-700 ease-out group-hover:scale-[1.05]"
                     pictureClassName="relative block h-full w-full"
                     resource={item.media}
-                    size={mediaSize}
+                    sizesPreset={mediaSizesPreset}
                   />
                 ) : null}
 

--- a/src/blocks/LogoGrid/Component.tsx
+++ b/src/blocks/LogoGrid/Component.tsx
@@ -64,6 +64,7 @@ export const LogoGridBlock: React.FC<LogoGridBlockProps> = ({
                         : 'dark:invert dark:opacity-80 dark:group-hover:opacity-100',
                     )}
                     resource={item.logo}
+                    sizesPreset="icon"
                   />
                 ) : null}
                 <span
@@ -110,6 +111,7 @@ export const LogoGridBlock: React.FC<LogoGridBlockProps> = ({
                           t === 'dark' ? 'invert opacity-90' : 'dark:invert dark:opacity-90',
                         )}
                         resource={item.logo}
+                        sizesPreset="icon"
                       />
                     ) : null}
                   </div>

--- a/src/blocks/SplitSection/Component.tsx
+++ b/src/blocks/SplitSection/Component.tsx
@@ -121,7 +121,7 @@ export const SplitSectionBlock: React.FC<SplitSectionBlockProps> = ({
               imgClassName="object-cover"
               pictureClassName="relative block h-full w-full"
               resource={media}
-              size="(max-width: 1024px) 100vw, 58vw"
+              sizesPreset="split"
             />
             {caption ? (
               <figcaption className={cn('mt-4', themeMutedText[t])}>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -42,7 +42,7 @@ export const Card: React.FC<{
             imgClassName="object-cover transition-transform duration-700 ease-out group-hover:scale-[1.04]"
             pictureClassName="absolute inset-0"
             resource={metaImage}
-            size="(max-width: 768px) 100vw, 33vw"
+            sizesPreset="third"
           />
         ) : null}
         {typeof index === 'number' && typeof total === 'number' ? (

--- a/src/components/Media/ImageMedia/index.tsx
+++ b/src/components/Media/ImageMedia/index.tsx
@@ -8,10 +8,9 @@ import React from 'react'
 
 import type { Props as MediaProps } from '../types'
 
-import { cssVariables } from '@/cssVariables'
 import { getMediaUrl } from '@/utilities/getMediaUrl'
-
-const { breakpoints } = cssVariables
+import { mediaSizes } from '../sizes'
+import { getResponsiveImageData } from './responsive'
 
 const isSvgPath = (value: string) => {
   try {
@@ -21,108 +20,103 @@ const isSvgPath = (value: string) => {
   }
 }
 
-// A base64 encoded image to use as a placeholder while the image is loading
-const placeholderBlur =
-  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAABchJREFUWEdtlwtTG0kMhHtGM7N+AAdcDsjj///EBLzenbtuadbLJaZUTlHB+tRqSesETB3IABqQG1KbUFqDlQorBSmboqeEBcC1d8zrCixXYGZcgMsFmH8B+AngHdurAmXKOE8nHOoBrU6opcGswPi5KSP9CcBaQ9kACJH/ALAA1xm4zMD8AczvQCcAQeJVAZsy7nYApTSUzwCHUKACeUJi9TsFci7AHmDtuHYqQIC9AgQYKnSwNAig4NyOOwXq/xU47gDYggarjIpsRSEA3Fqw7AGkwgW4fgALAdiC2btKgNZwbgdMbEFpqFR2UyCR8xwAhf8bUHIGk1ckMyB5C1YkeWAdAPQBAeiD6wVYPoD1HUgXwFagZAGc6oSpTmilopoD5GzISQD3odcNIFca0BUQQM5YA2DpHV0AYURBDIAL0C+ugC0C4GedSsVUmwC8/4w8TPiwU6AClJ5RWL1PgQNkrABWdKB3YF3cBwRY5lsI4ApkKpCQi+FIgFJU/TDgDuAxAAwonJuKpGD1rkCXCR1ALyrAUSSEQAhwBdYZ6DPAgSUA2c1wKIZmRcHxMzMYR9DH8NlbkAwwApSAcABwBwTAbb6owAr0AFiZPILVEyCtMmK2jCkTwFDNUNj7nJETQx744gCUmgkZVGJUHyakEZE4W91jtGFA9KsD8Z3JFYDlhGYZLWcllwJMnplcPy+csFAgAAaIDOgeuAGoB96GLZg4kmtfMjnr6ig5oSoySsoy3ya/FMivXZWxwr0KIf9nACbfqcBEgmBSAtAlIT83R+70IWpyACamIjf5E1Iqb9ECVmnoI/FvAIRk8s2J0Y5IquQDgB+5wpScw5AUTC75VTmTs+72NUzoCvQIaAXv5Q8PDAZKLD+MxLv3RFE7KlsQChgBIlKiCv5ByaZv3gJZNm8AnVMhAN+EjrtTYQMICJpu6/0aiQnhClANlz+Bw0cIWa8ev0sBrtrhAyaXEnrfGfATQJiRKih5vKeOHNXXPFrgyamAADh0Q4F2/sESojomDS9o9k0b0H83xjB8qL+JNoTjN+enjpaBpingRh4e8MSugudM030A8FeqMI6PFIgNyPehkpZWGFEAARIQdH5LcAAqIACHkAJqg4OoBccHAuz76wr4BbzFOEa8iBuAZB8AtJHLP2VgMgJw/EIBowo7HxCAH3V6dAXEE/vZ5aZIA8BP8RKhm7Cp8BnAMnAQADdgQDA520AVIpScP+enHz0Gwp25h4i2dPg5FkDXrbsdJikQwXuWgaM5gEMk1AgH4DKKFjDf3bMD+FjEeIxLlRKYnBk2BbquvSDCAQ4gwZiMAAmH4gBTyRtEsYxi7gP6QSrc//39BrDNqG8rtYTmC4BV1SfMhOhaumFCT87zy4pPhQBZEK1kQVRjJBBi7AOlePgyAPYjwlvtagx9e/dnQraAyS894TIkkAIEYMKEc8k4EqJ68lZ5jjNqcQC2QteQOf7659umwBgPybNtK4dg9WvnMyFwXYGP7uEO1lwJgAnPNeMYMVXbIIYKFioI4PGFt+BWPVfmWJdjW2lTUnLGCswECAgaUy86iwA1464ajo0QhgMBFGyBoZahANsMpMfXr1JA1SN29m5lqgXj+UPV85uRA7yv/KYUO4Tk7Hc1AZwbIRzg0AyNj2UlAMwfSLSMnl7fdAbcxHuA27YaAMvaQ4GOjwX4RTUGAG8Ge14N963g1AynqUiFqRX9noasxT4b8entNRQYyamk/3tYcHsO7R3XJRRYOn4tw4iUnwBM5gDnySGOreAwAGo8F9IDHEcq8Pz2Kg/oXCpuIL6tOPD8LsDn0ABYQoGFRowlsAEUPPDrGAGowAbgKsgDMmE8mDy/vXQ9IAwI7u4wta+gAdAdgB64Ah9SgD4IgGKhwACoAjgNgFDhtxY8f33ZTMjqdTAiHMBPrn8ZWkEfzFdX4Oc1AHg3+ADbvN8PU8WdFKg4Tt6CQy2+D4YHaMT/JP4XzbAq98cPDIUAAAAASUVORK5CYII='
-
-/**
- * ImageMedia
- *
- * This component passes local Payload media as root-relative URLs and external
- * media as absolute URLs. Relative URLs avoid needing localhost in Next Image's
- * `remotePatterns` while still allowing configured remote storage hosts.
- *
- * Flow:
- *   1. Resource URL from Payload: `/api/media/file/image-123.jpg`
- *   2. getMediaUrl() keeps it root-relative for same-origin optimization
- *   3. Next.js Image optimizes via `/_next/image?url=...&w=1200&q=75`
- *
- * If your storage/plugin returns **external CDN URLs** (e.g. `https://cdn.example.com/...`),
- * choose ONE of the following:
- *   A) Allow the remote host in next.config.js:
- *      images: { remotePatterns: [{ protocol: 'https', hostname: 'cdn.example.com' }] }
- *   B) Provide a **custom loader** for CDN-specific transforms:
- *      const imageLoader: ImageLoader = ({ src, width, quality }) =>
- *        `https://cdn.example.com${src}?w=${width}&q=${quality ?? 75}`
- *      <Image loader={imageLoader} src="/media/hero.jpg" width={1200} height={600} alt="" />
- *   C) Skip optimization:
- *      <Image unoptimized src="https://cdn.example.com/hero.jpg" width={1200} height={600} alt="" />
- *
- * TL;DR: local Payload media should stay relative; only external media relies on
- * `remotePatterns`. Add a `loader` only for external CDNs with custom transforms.
- */
+const StaticImage: React.FC<{
+  alt: string
+  fill?: boolean
+  imgClassName?: string
+  loading?: 'eager' | 'lazy'
+  pictureClassName?: string
+  priority?: boolean
+  sizes: string
+  src: StaticImageData
+}> = ({ alt, fill, imgClassName, loading, pictureClassName, priority, sizes, src }) => {
+  return (
+    <picture className={cn(pictureClassName)}>
+      <NextImage
+        alt={alt}
+        className={cn(imgClassName)}
+        fill={fill}
+        loading={priority ? undefined : (loading ?? 'lazy')}
+        placeholder={src.blurDataURL ? 'blur' : 'empty'}
+        preload={priority}
+        sizes={sizes}
+        src={src}
+      />
+    </picture>
+  )
+}
 
 export const ImageMedia: React.FC<MediaProps> = (props) => {
   const {
     alt: altFromProps,
     fill,
-    pictureClassName,
     imgClassName,
+    loading: loadingFromProps,
+    pictureClassName,
     priority,
     resource,
-    size: sizeFromProps,
+    sizes: sizesFromProps,
+    sizesPreset,
     src: srcFromProps,
-    loading: loadingFromProps,
   } = props
 
-  let width: number | undefined
-  let height: number | undefined
-  let alt = altFromProps
-  let src: StaticImageData | string = srcFromProps || ''
+  const sizes = sizesFromProps ?? mediaSizes[sizesPreset ?? 'full']
 
-  if (!src && resource && typeof resource === 'object') {
-    const { alt: altFromResource, height: fullHeight, url, width: fullWidth } = resource
-
-    width = fullWidth!
-    height = fullHeight!
-    alt = altFromResource || ''
-
-    const cacheTag = resource.updatedAt
-
-    src = getMediaUrl(url, cacheTag)
+  if (srcFromProps) {
+    return (
+      <StaticImage
+        alt={altFromProps ?? ''}
+        fill={fill}
+        imgClassName={imgClassName}
+        loading={loadingFromProps}
+        pictureClassName={pictureClassName}
+        priority={priority}
+        sizes={sizes}
+        src={srcFromProps}
+      />
+    )
   }
 
-  const loading = loadingFromProps || (!priority ? 'lazy' : undefined)
-  const isPayloadSvg = typeof resource === 'object' && resource?.mimeType === 'image/svg+xml'
-  const svgSrc = typeof src === 'string' && (isPayloadSvg || isSvgPath(src)) ? src : null
+  if (!resource || typeof resource !== 'object') return null
 
-  // NOTE: this is used by the browser to determine which image to download at different screen sizes
-  const sizes = sizeFromProps
-    ? sizeFromProps
-    : Object.entries(breakpoints)
-        .map(([, value]) => `(max-width: ${value}px) ${value * 2}w`)
-        .join(', ')
+  const alt = altFromProps ?? resource.alt ?? ''
+  const isSvg = resource.mimeType === 'image/svg+xml' || isSvgPath(resource.url ?? '')
 
-  if (svgSrc) {
+  if (isSvg) {
+    if (!resource.url) return null
+
     return (
       <picture className={cn(pictureClassName)}>
         <img
-          alt={alt || ''}
-          className={cn(imgClassName)}
-          height={height}
-          loading={loading}
-          src={svgSrc}
-          width={width}
+          alt={alt}
+          className={cn(fill && 'absolute inset-0 h-full w-full', imgClassName)}
+          decoding="async"
+          fetchPriority={priority ? 'high' : undefined}
+          height={fill ? undefined : (resource.height ?? undefined)}
+          loading={priority ? 'eager' : (loadingFromProps ?? 'lazy')}
+          src={getMediaUrl(resource.url, resource.updatedAt)}
+          width={fill ? undefined : (resource.width ?? undefined)}
         />
       </picture>
     )
   }
 
+  const image = getResponsiveImageData(resource)
+  if (!image) return null
+
   return (
     <picture className={cn(pictureClassName)}>
-      <NextImage
-        alt={alt || ''}
-        className={cn(imgClassName)}
-        fill={fill}
-        height={!fill ? height : undefined}
-        placeholder="blur"
-        blurDataURL={placeholderBlur}
-        priority={priority}
-        quality={100}
-        loading={loading}
-        sizes={sizes}
-        src={src}
-        width={!fill ? width : undefined}
+      <img
+        alt={alt}
+        className={cn(fill && 'absolute inset-0 h-full w-full', imgClassName)}
+        decoding="async"
+        fetchPriority={priority ? 'high' : undefined}
+        height={fill ? undefined : image.height}
+        loading={priority ? 'eager' : (loadingFromProps ?? 'lazy')}
+        sizes={image.srcSet ? sizes : undefined}
+        src={image.src}
+        srcSet={image.srcSet}
+        width={fill ? undefined : image.width}
       />
     </picture>
   )

--- a/src/components/Media/ImageMedia/responsive.ts
+++ b/src/components/Media/ImageMedia/responsive.ts
@@ -1,0 +1,52 @@
+import type { Media } from '@/payload-types'
+import { getMediaUrl } from '@/utilities/getMediaUrl'
+
+const responsiveSizeNames = ['thumbnail', 'small', 'medium', 'large', 'xlarge'] as const
+
+export type ResponsiveImageData = {
+  height?: number
+  src: string
+  srcSet?: string
+  width?: number
+}
+
+const inferHeight = (media: Media, width: number, height?: number | null) => {
+  if (height && height > 0) return height
+  if (!media.width || !media.height) return undefined
+  return Math.round((width * media.height) / media.width)
+}
+
+export const getResponsiveImageData = (media: Media): ResponsiveImageData | null => {
+  const candidates = responsiveSizeNames
+    .map((name) => media.sizes?.[name])
+    .flatMap((size) => {
+      if (!size?.url || !size.width || size.width <= 0) return []
+
+      return [
+        {
+          height: inferHeight(media, size.width, size.height),
+          src: getMediaUrl(size.url, media.updatedAt),
+          width: size.width,
+        },
+      ]
+    })
+    .sort((a, b) => a.width - b.width)
+
+  const largest = candidates.at(-1)
+  if (largest) {
+    return {
+      height: largest.height,
+      src: largest.src,
+      srcSet: candidates.map(({ src, width }) => `${src} ${width}w`).join(', '),
+      width: largest.width,
+    }
+  }
+
+  if (!media.url) return null
+
+  return {
+    height: media.height && media.height > 0 ? media.height : undefined,
+    src: getMediaUrl(media.url, media.updatedAt),
+    width: media.width && media.width > 0 ? media.width : undefined,
+  }
+}

--- a/src/components/Media/VideoMedia/index.tsx
+++ b/src/components/Media/VideoMedia/index.tsx
@@ -24,7 +24,7 @@ export const VideoMedia: React.FC<MediaProps> = (props) => {
   }, [])
 
   if (resource && typeof resource === 'object') {
-    const { filename } = resource
+    if (!resource.url) return null
 
     return (
       <video
@@ -37,7 +37,7 @@ export const VideoMedia: React.FC<MediaProps> = (props) => {
         playsInline
         ref={videoRef}
       >
-        <source src={getMediaUrl(`/media/${filename}`)} />
+        <source src={getMediaUrl(resource.url, resource.updatedAt)} />
       </video>
     )
   }

--- a/src/components/Media/sizes.ts
+++ b/src/components/Media/sizes.ts
@@ -1,0 +1,17 @@
+export const mediaSizes = {
+  affinity: '(max-width: 768px) 100vw, (max-width: 1344px) 50vw, 672px',
+  avatar: '(max-width: 768px) 128px, 160px',
+  content: '(max-width: 768px) 100vw, 1360px',
+  full: '100vw',
+  galleryHalf: '50vw',
+  galleryQuarter: '(max-width: 768px) 50vw, 25vw',
+  galleryThird: '(max-width: 768px) 50vw, 33vw',
+  half: '(max-width: 768px) 100vw, 50vw',
+  icon: '64px',
+  portraitGrid: '(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw',
+  quarter: '(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 25vw',
+  split: '(max-width: 1024px) 100vw, 58vw',
+  third: '(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw',
+} as const
+
+export type MediaSizesPreset = keyof typeof mediaSizes

--- a/src/components/Media/types.ts
+++ b/src/components/Media/types.ts
@@ -2,21 +2,23 @@ import type { StaticImageData } from 'next/image'
 import type { ElementType, Ref } from 'react'
 
 import type { Media as MediaType } from '@/payload-types'
+import type { MediaSizesPreset } from './sizes'
 
 export interface Props {
   alt?: string
   className?: string
-  fill?: boolean // for NextImage only
+  fill?: boolean
   htmlElement?: ElementType | null
   pictureClassName?: string
   imgClassName?: string
   onClick?: () => void
   onLoad?: () => void
-  loading?: 'lazy' | 'eager' // for NextImage only
-  priority?: boolean // for NextImage only
+  loading?: 'lazy' | 'eager'
+  priority?: boolean
   ref?: Ref<HTMLImageElement | HTMLVideoElement | null>
   resource?: MediaType | string | number | null // for Payload media
-  size?: string // for NextImage only
+  sizes?: string
+  sizesPreset?: MediaSizesPreset
   src?: StaticImageData // for static media
   videoClassName?: string
 }

--- a/src/heros/AffinityGroup/index.tsx
+++ b/src/heros/AffinityGroup/index.tsx
@@ -14,7 +14,11 @@ export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richTe
         <div className="flex flex-col items-start gap-4 md:gap-6">
           {logo && typeof logo === 'object' && (
             <div className="mb-2">
-              <Media resource={logo} imgClassName="w-16 h-16 md:w-20 md:h-20 object-contain" />
+              <Media
+                resource={logo}
+                imgClassName="w-16 h-16 md:w-20 md:h-20 object-contain"
+                sizesPreset="icon"
+              />
             </div>
           )}
 
@@ -46,6 +50,7 @@ export const AffinityGroupHero: React.FC<Page['hero']> = ({ links, media, richTe
               resource={media}
               className="w-full max-w-2xl overflow-hidden rounded-2xl border border-border bg-background"
               imgClassName="w-full max-h-[28rem] object-contain"
+              sizesPreset="affinity"
             />
           </div>
         )}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -95,7 +95,11 @@ export default buildConfig({
     ...plugins,
     vercelBlobStorage({
       collections: {
-        media: true,
+        // Media is publicly readable, so serve files directly from Vercel Blob
+        // instead of proxying every request through the Payload function.
+        media: {
+          disablePayloadAccessControl: true,
+        },
       },
 token: process.env.BLOB_READ_WRITE_TOKEN ?? (() => { throw new Error('Missing required env var: BLOB_READ_WRITE_TOKEN') })(),
     }),

--- a/src/utilities/getGlobals.ts
+++ b/src/utilities/getGlobals.ts
@@ -5,6 +5,7 @@ import { getPayload } from 'payload'
 import { unstable_cache } from 'next/cache'
 
 type Global = keyof Config['globals']
+const mediaDeliveryCacheVersion = 'direct-blob-v1'
 
 async function getGlobal(slug: Global, depth = 0, locale?: Config['locale']) {
   const payload = await getPayload({ config: configPromise })
@@ -25,7 +26,7 @@ async function getGlobal(slug: Global, depth = 0, locale?: Config['locale']) {
 export const getCachedGlobal = (slug: Global, depth = 0, locale?: Config['locale']) =>
   unstable_cache(
     async () => getGlobal(slug, depth, locale),
-    [slug, String(depth), locale ?? 'default'],
+    [mediaDeliveryCacheVersion, slug, String(depth), locale ?? 'default'],
     {
       tags: [`global_${slug}`, `global_${slug}_${locale ?? 'en'}`],
     },

--- a/tests/int/responsiveMedia.int.spec.ts
+++ b/tests/int/responsiveMedia.int.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import type { Media } from '@/payload-types'
+import { ImageMedia } from '@/components/Media/ImageMedia'
+import { getResponsiveImageData } from '@/components/Media/ImageMedia/responsive'
+
+const updatedAt = '2026-08-08T20:27:40.013Z'
+
+const createMedia = (overrides: Partial<Media> = {}): Media => ({
+  alt: 'IEEE uOttawa',
+  createdAt: updatedAt,
+  height: 4000,
+  id: 146,
+  mimeType: 'image/jpeg',
+  sizes: {
+    large: {
+      height: 933,
+      url: 'https://media.example.com/hero-1400x933.jpg',
+      width: 1400,
+    },
+    medium: {
+      height: 600,
+      url: 'https://media.example.com/hero-900x600.jpg',
+      width: 900,
+    },
+    og: {
+      height: 630,
+      url: 'https://media.example.com/hero-1200x630.jpg',
+      width: 1200,
+    },
+    small: {
+      height: 400,
+      url: 'https://media.example.com/hero-600x400.jpg',
+      width: 600,
+    },
+    square: {
+      height: 500,
+      url: 'https://media.example.com/hero-500x500.jpg',
+      width: 500,
+    },
+    thumbnail: {
+      height: 200,
+      url: 'https://media.example.com/hero-300x200.jpg',
+      width: 300,
+    },
+    xlarge: {
+      height: 1280,
+      url: 'https://media.example.com/hero-1920x1280.jpg',
+      width: 1920,
+    },
+  },
+  updatedAt,
+  url: 'https://media.example.com/hero.jpg',
+  width: 6000,
+  ...overrides,
+})
+
+describe('Payload responsive media', () => {
+  it('uses aspect-preserving Payload sizes and avoids the oversized original', () => {
+    const image = getResponsiveImageData(createMedia())
+
+    expect(image?.src).toContain('hero-1920x1280.jpg')
+    expect(image?.src).not.toContain('/hero.jpg')
+    expect(image?.srcSet).toMatch(/ 300w,.* 600w,.* 900w,.* 1400w,.* 1920w/)
+    expect(image?.srcSet).not.toContain('hero-500x500.jpg')
+    expect(image?.srcSet).not.toContain('hero-1200x630.jpg')
+    expect(image?.srcSet).toContain(encodeURIComponent(updatedAt))
+  })
+
+  it('falls back to the original URL when legacy media has no generated sizes', () => {
+    const image = getResponsiveImageData(createMedia({ sizes: undefined }))
+
+    expect(image).toMatchObject({
+      height: 4000,
+      src: expect.stringContaining('/hero.jpg'),
+      width: 6000,
+    })
+    expect(image?.srcSet).toBeUndefined()
+  })
+
+  it('infers missing derivative heights from the original aspect ratio', () => {
+    const image = getResponsiveImageData(
+      createMedia({
+        sizes: {
+          small: {
+            height: null,
+            url: 'https://media.example.com/hero-900.webp',
+            width: 900,
+          },
+        },
+      }),
+    )
+
+    expect(image?.height).toBe(600)
+  })
+
+  it('renders priority CMS images without the Next runtime optimizer', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(ImageMedia, {
+        fill: true,
+        priority: true,
+        resource: createMedia(),
+        sizesPreset: 'half',
+      }),
+    )
+
+    expect(markup).toContain('srcSet=')
+    expect(markup).toContain('sizes="(max-width: 768px) 100vw, 50vw"')
+    expect(markup).toContain('fetchPriority="high"')
+    expect(markup).toContain('loading="eager"')
+    expect(markup).not.toContain('rel="preload"')
+    expect(markup).not.toContain('/_next/image')
+    expect(markup).not.toContain('hero.jpg?')
+  })
+})


### PR DESCRIPTION
Previously, cache misses on page load caused Next.js to attempt to optimize full sized pictures, causing really slow load times. Now, the page loads the payload optimized image directly.